### PR TITLE
UX改善: カテゴリー廃止・カード全体クリック化・Instagram投稿埋め込み・エリアパンくず

### DIFF
--- a/events.json
+++ b/events.json
@@ -71,7 +71,8 @@
     "admission": "無料",
     "sourceUrl": "https://www.instagram.com/fukuoka_green_party/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-29"
+    "addedDate": "2026-04-29",
+    "instagramUrl": "https://www.instagram.com/p/DTH4ktKEhUq/"
   },
   {
     "slug": "plant-freaks-special-2026-05",
@@ -483,7 +484,8 @@
       "即売会"
     ],
     "status": "upcoming",
-    "url": "https://www.instagram.com/reel/DTEIXiekx1D/"
+    "url": "https://www.instagram.com/reel/DTEIXiekx1D/",
+    "instagramUrl": "https://www.instagram.com/reel/DTEIXiekx1D/"
   },
   {
     "slug": "plants-garage-market-2026-spring",
@@ -1238,7 +1240,8 @@
       "即売会"
     ],
     "status": "past",
-    "url": "https://www.instagram.com/p/DVxEjm0iWCA/"
+    "url": "https://www.instagram.com/p/DVxEjm0iWCA/",
+    "instagramUrl": "https://www.instagram.com/p/DVxEjm0iWCA/"
   },
   {
     "slug": "aichi-plants-fes-vol1",

--- a/events/agave-meeting-2026-kobe.html
+++ b/events/agave-meeting-2026-kobe.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "近畿のイベント",
+        "item": "https://agave-navi.com/?region=%E8%BF%91%E7%95%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt;
     <span>AGAVE MEETING 2026 KOBE</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月12日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/aichi-plants-fes-vol1.html
+++ b/events/aichi-plants-fes-vol1.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; AICHI植フェス Vol.1</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt; AICHI植フェス Vol.1</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=AICHI植フェス Vol.1&dates=20260425%2F20260427&location=愛知&details=AICHI植フェス Vol.1+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/aichin-shokusai-2026.html
+++ b/events/aichin-shokusai-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "東海のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E6%B5%B7"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E6%B5%B7">東海のイベント</a> &gt;
     <span>愛珍植祭2026</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">刈谷市産業振興センター あいおいホール</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/bizarrefarm-spring-fes-2026.html
+++ b/events/bizarrefarm-spring-fes-2026.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>bizarrefarm SPRING FES 2026</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -162,10 +162,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/border-break-6th-2026.html
+++ b/events/border-break-6th-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; BORDER BREAK!! 6th</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; BORDER BREAK!! 6th</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
                 </div>
             </div>
 
@@ -122,10 +122,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">前売あり（詳細未定）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">大型、即売会、展示会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">開催地域</span>

--- a/events/bota-magic-2026.html
+++ b/events/bota-magic-2026.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>BOTA☆MAGIC</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -162,10 +162,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/botanic-bomb-10th-kyoto-2026.html
+++ b/events/botanic-bomb-10th-kyoto-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>BOTANIC BOMB 10TH（ボタニックボム）</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">三段池公園</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/botanical-botanical-osaka.html
+++ b/events/botanical-botanical-osaka.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>BOTANICAL BOTANICAL OSAKA</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -161,10 +161,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,大型</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/botanical-botanical-tokyo-2026.html
+++ b/events/botanical-botanical-tokyo-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>BOTANICAL BOTANICAL TOKYO</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">東京都内</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/botanical-circus-7-2026.html
+++ b/events/botanical-circus-7-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>Botanical Circus 7</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/botanical-marche-kanazawa-2026.html
+++ b/events/botanical-marche-kanazawa-2026.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; ボタニカルマルシェ金沢2026</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt; ボタニカルマルシェ金沢2026</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=ボタニカルマルシェ金沢2026&dates=20260509%2F20260510&location=石川&details=ボタニカルマルシェ金沢2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/botanical-market-akita-2026.html
+++ b/events/botanical-market-akita-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "東北のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E5%8C%97"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt;
     <span>ボタニカルマーケット</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">道の駅うご 端縫いの郷</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/bromeliad-festa-spring-2026.html
+++ b/events/bromeliad-festa-spring-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>BROMELIAD FESTA SPRING 2026</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">板橋区立文化会館</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,ブロメリア</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/bts-beppu-taniku-show-2026.html
+++ b/events/bts-beppu-taniku-show-2026.html
@@ -116,12 +116,6 @@
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月18日（土）</span>
           </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
-          </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">九州</span>

--- a/events/chinki-shokubutsu-freemarket-machida-2026.html
+++ b/events/chinki-shokubutsu-freemarket-machida-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>珍奇植物フリーマーケット</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">町田パリオ 4階</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/chinki-shokubutsu-ichiba-vol8-2026.html
+++ b/events/chinki-shokubutsu-ichiba-vol8-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>珍奇植物市場 Vol.8</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">西原さわふじマルシェ さわふじ広場</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/coco-et-nico-bond-project-2026.html
+++ b/events/coco-et-nico-bond-project-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>COCO ET NICO presents Bond PROJECT</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">市原湖畔美術館</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/collect-plants-vol2.html
+++ b/events/collect-plants-vol2.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; Collect Plants Vol.2</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt; Collect Plants Vol.2</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -94,7 +94,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
                 </div>
             </div>
 
@@ -116,10 +116,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">大型イベント、即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">公式</span>

--- a/events/engei-yaroze-vol11-2026.html
+++ b/events/engei-yaroze-vol11-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>園藝野郎勢 Vol.11 2026 春の陣</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fuji-taniku-plants-marche-2026.html
+++ b/events/fuji-taniku-plants-marche-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "東海のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E6%B5%B7"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E6%B5%B7">東海のイベント</a> &gt;
     <span>富士多肉プランツマルシェ</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">啓芳園</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fujisan-festa.html
+++ b/events/fujisan-festa.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "中部のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E9%83%A8"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt;
     <span>FUJISAN FESTA</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年5月3日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,大型</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fujiyama-days-little-green-park-2026.html
+++ b/events/fujiyama-days-little-green-park-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>FUJIYAMA DAYS LITTLE GREEN PARK</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fukuoka-green-party-2026.html
+++ b/events/fukuoka-green-party-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>FUKUOKA GREEN PARTY 2026</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年5月3日（日） 〜 5月4日（月）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fukuoka-green-party-6th-2026.html
+++ b/events/fukuoka-green-party-6th-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>第6回 福岡グリーンパーティー</span>
   </nav>
 
@@ -135,8 +135,16 @@
           </div>
         </div>
 
+        <div class="detail-section detail-instagram-embed">
+          <h2 class="detail-section-title">Instagram投稿</h2>
+          <div class="instagram-embed-wrap">
+            <iframe src="https://www.instagram.com/p/DTH4ktKEhUq/embed/" loading="lazy" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>
+          </div>
+          <p class="instagram-embed-link"><a href="https://www.instagram.com/p/DTH4ktKEhUq/" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
+        </div>
+
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +158,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">志摩中央公園</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fukutomo-marche-3-2026.html
+++ b/events/fukutomo-marche-3-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>第3回 福友マルシェ</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/fumakilla-kadan-fes-2026.html
+++ b/events/fumakilla-kadan-fes-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sale.html">即売会一覧</a> &gt; フマキラーカダンフェス</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; フマキラーカダンフェス</div>
 
     <main class="detail-page">
         </div>
@@ -96,7 +96,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sale.html" class="detail-back-link">即売会一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
                 </div>
             </div>
 
@@ -114,10 +114,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">開催地域</span>

--- a/events/fushimi-daisakusen-vol2.html
+++ b/events/fushimi-daisakusen-vol2.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; 伏見大作戦 vol.2</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; 伏見大作戦 vol.2</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=伏見大作戦 vol.2&dates=20260516%2F20260517&location=京都&details=伏見大作戦 vol.2+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/futakotamagawa-botanical-2026.html
+++ b/events/futakotamagawa-botanical-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; 二子玉川ボタニカルフェスタ 2026春</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; 二子玉川ボタニカルフェスタ 2026春</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -97,7 +97,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -119,10 +119,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">500円（税込）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">大型イベント、展示会、即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF+2026%E6%98%A5&dates=20260404T100000%2F20260405T170000&location=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%A9%E3%82%A4%E3%82%BA%2C+%E6%9D%B1%E4%BA%AC%E9%83%BD&details=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF+2026%E6%98%A5+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/gotanda-big-bazaar-2026-05.html
+++ b/events/gotanda-big-bazaar-2026-05.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; サボテン・多肉植物ビッグバザール（5月）</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; サボテン・多肉植物ビッグバザール（5月）</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -122,10 +122,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">500円</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会、大型</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">開催頻度</span>

--- a/events/grateful-days-10th-osaka-2026.html
+++ b/events/grateful-days-10th-osaka-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>Grateful Days 〜 The 10th episode 〜</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">大阪</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/green-breeze-fes-vol3.html
+++ b/events/green-breeze-fes-vol3.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; GREEN BREEZE FES vol.3</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; GREEN BREEZE FES vol.3</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
                 </div>
             </div>
 
@@ -117,10 +117,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ、即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GREEN+BREEZE+FES+vol.3&dates=20260531%2F20260601&location=%E5%92%8C%E6%AD%8C%E5%B1%B1%E5%B8%82&details=GREEN+BREEZE+FES+vol.3+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/green-day-vol15-2026.html
+++ b/events/green-day-vol15-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>Green Day vol.15</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/greensnap-marche-hiroshima-2026.html
+++ b/events/greensnap-marche-hiroshima-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; GreenSnap Marche HIROSHIMA 2026</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt; GreenSnap Marche HIROSHIMA 2026</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -97,7 +97,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
                 </div>
             </div>
 
@@ -119,10 +119,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ、即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">主催</span>

--- a/events/greensnap-marche-toyosu-2026.html
+++ b/events/greensnap-marche-toyosu-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>GreenSnap Marche 豊洲 2026</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">豊洲公園</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/greensnap-marche-yokohama-2026.html
+++ b/events/greensnap-marche-yokohama-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; GreenSnap Marche YOKOHAMA 2026</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; GreenSnap Marche YOKOHAMA 2026</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -122,10 +122,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ、大型、即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">主催</span>

--- a/events/hanatomofesta-2026.html
+++ b/events/hanatomofesta-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; 第8回 花友フェスタ 2026</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; 第8回 花友フェスタ 2026</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -94,7 +94,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
                 </div>
             </div>
 
@@ -116,10 +116,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">大型イベント、マルシェ</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">公式</span>

--- a/events/hanauchu-dream-garden-26.html
+++ b/events/hanauchu-dream-garden-26.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "近畿のイベント",
+        "item": "https://agave-navi.com/?region=%E8%BF%91%E7%95%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt;
     <span>第26回 花宇宙ドリームガーデン</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月10日（金） 〜 4月12日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/happy-smile-odawara-2026.html
+++ b/events/happy-smile-odawara-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sale.html">即売会一覧</a> &gt; HAPPY SMILE</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; HAPPY SMILE</div>
 
     <main class="detail-page">
         </div>
@@ -96,7 +96,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sale.html" class="detail-back-link">即売会一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -114,10 +114,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">開催地域</span>

--- a/events/haru-cactus-succulent-kuro-toyama-2026.html
+++ b/events/haru-cactus-succulent-kuro-toyama-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "展示会一覧",
-        "item": "https://agave-navi.com/category/exhibition.html"
+        "name": "北陸のイベント",
+        "item": "https://agave-navi.com/?region=%E5%8C%97%E9%99%B8"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/exhibition.html">展示会一覧</a> &gt;
+    <a href="/?region=%E5%8C%97%E9%99%B8">北陸のイベント</a> &gt;
     <span>春のサボテン・多肉植物展 ―特別展示 黒―</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/exhibition.html" class="detail-back-link">展示会一覧に戻る</a>
+          <a href="/?region=%E5%8C%97%E9%99%B8" class="detail-back-link">北陸のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">富山県中央植物園</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">展示会,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/haru-saboten-taniku-fair-2026.html
+++ b/events/haru-saboten-taniku-fair-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>春のサボテン多肉植物フェア</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/haru-saboten-taniku-fair-sapporo-2026.html
+++ b/events/haru-saboten-taniku-fair-sapporo-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "北海道のイベント",
+        "item": "https://agave-navi.com/?region=%E5%8C%97%E6%B5%B7%E9%81%93"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%8C%97%E6%B5%B7%E9%81%93">北海道のイベント</a> &gt;
     <span>春のサボテン多肉植物フェア</span>
   </nav>
 
@@ -134,8 +134,16 @@
           </div>
         </div>
 
+        <div class="detail-section detail-instagram-embed">
+          <h2 class="detail-section-title">Instagram投稿</h2>
+          <div class="instagram-embed-wrap">
+            <iframe src="https://www.instagram.com/p/DVxEjm0iWCA/embed/" loading="lazy" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>
+          </div>
+          <p class="instagram-embed-link"><a href="https://www.instagram.com/p/DVxEjm0iWCA/" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
+        </div>
+
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%8C%97%E6%B5%B7%E9%81%93" class="detail-back-link">北海道のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +158,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">札幌市北区新琴似町787-1-4</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/haru-saboten-wakayama-2026.html
+++ b/events/haru-saboten-wakayama-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>春のサボテン即売会</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">和歌山</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/haze-various-genres-marche-2026.html
+++ b/events/haze-various-genres-marche-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>HAZE -various genres marche</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">茨城県内会場</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/himeji-kisotengai-shokubutsuichi-2026.html
+++ b/events/himeji-kisotengai-shokubutsuichi-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>姫路城 奇草天外な植物市</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">姫路城</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/hobby-plants-freaks-vol5.html
+++ b/events/hobby-plants-freaks-vol5.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; Hobby Plants Freaks Vol5</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt; Hobby Plants Freaks Vol5</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Hobby Plants Freaks Vol5&dates=20260425%2F20260427&location=岡山&details=Hobby Plants Freaks Vol5+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/hosokawa-botafes-2026-spring.html
+++ b/events/hosokawa-botafes-2026-spring.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>HOSOKAWA BOTAFES '26 spring</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">旧細河小学校</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/ibaraki-sky-palette-2026.html
+++ b/events/ibaraki-sky-palette-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>いばらきスカイパレット 植物マルシェ</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年2月21日（土）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/iku-matsuri-ichinomiya-spring.html
+++ b/events/iku-matsuri-ichinomiya-spring.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "中部のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E9%83%A8"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt;
     <span>樹祭 in 一宮 2026春</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月11日（土） 〜 4月12日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,大型</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/iku-matsuri-utsunomiya-2026.html
+++ b/events/iku-matsuri-utsunomiya-2026.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; 樹祭 in 宇都宮 2026</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; 樹祭 in 宇都宮 2026</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会、大型</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%B9%E7%A5%AD+in+%E5%AE%87%E9%83%BD%E5%AE%AE+2026&dates=20260530%2F20260601&location=%E6%A0%83%E6%9C%A8%E7%9C%8C%E5%AE%87%E9%83%BD%E5%AE%AE%E5%B8%82&details=%E6%A8%B9%E7%A5%AD+in+%E5%AE%87%E9%83%BD%E5%AE%AE+2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/isij-big-bazaar-2026-05-24.html
+++ b/events/isij-big-bazaar-2026-05-24.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "大型イベント一覧",
-        "item": "https://agave-navi.com/category/large.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/large.html">大型イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>5月のサボテン・多肉植物ビッグバザール</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">五反田TOCビル 13階</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">大型,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/isij-big-bazaar-2026-07-12.html
+++ b/events/isij-big-bazaar-2026-07-12.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "大型イベント一覧",
-        "item": "https://agave-navi.com/category/large.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/large.html">大型イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>7月のサボテン・多肉植物ビッグバザール</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">五反田TOCビル 13階</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">大型,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/isij-big-bazaar-2026-09-27.html
+++ b/events/isij-big-bazaar-2026-09-27.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "大型イベント一覧",
-        "item": "https://agave-navi.com/category/large.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/large.html">大型イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>9月のサボテン・多肉植物ビッグバザール</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">五反田TOCビル 13階</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">大型,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/isij-big-bazaar-2026-11-22.html
+++ b/events/isij-big-bazaar-2026-11-22.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "大型イベント一覧",
-        "item": "https://agave-navi.com/category/large.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/large.html">大型イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>11月のサボテン・多肉植物ビッグバザール</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">五反田TOCビル 13階</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">大型,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/iwate-hana-midori-matsuri-2026.html
+++ b/events/iwate-hana-midori-matsuri-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "東北のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E5%8C%97"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt;
     <span>花と緑のまつり</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">岩手</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/jiyugaoka-botanical-market-2026.html
+++ b/events/jiyugaoka-botanical-market-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>Jiyugaoka Botanical Market</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">自由が丘</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/joyful-festival-2026.html
+++ b/events/joyful-festival-2026.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>JOYFUL FESTIVAL</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -162,10 +162,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/jr-takashimaya-raflum-2026.html
+++ b/events/jr-takashimaya-raflum-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>JR名古屋タカシマヤ × RAFLUM ポップアップ</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,塊根植物</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/jungle-plants-market.html
+++ b/events/jungle-plants-market.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>JUNGLE PLANTS MARKET</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月12日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/kisarazu-cs-fair.html
+++ b/events/kisarazu-cs-fair.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; KISARAZU C&S FAIR</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; KISARAZU C&S FAIR</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=KISARAZU C&S FAIR&dates=20260426%2F20260427&location=千葉&details=KISARAZU C&S FAIR+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/kumagaya-taniku-fes-2026.html
+++ b/events/kumagaya-taniku-fes-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>第2回 熊谷多肉フェス</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年2月14日（土） 〜 2月15日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/mebuki-sai-2026.html
+++ b/events/mebuki-sai-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>芽吹祭</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/mini-soransai-june-2026.html
+++ b/events/mini-soransai-june-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>ミニ草乱祭（6月）</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">シマムラ園芸 第2ハウス</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/miyashita-park-popup-2026.html
+++ b/events/miyashita-park-popup-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>MIYASHITA PARK Pop-Up Store</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">MIYASHITA PARK</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/monster-plants-2026.html
+++ b/events/monster-plants-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "大型イベント一覧",
-        "item": "https://agave-navi.com/category/large.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/large.html">大型イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>モンスタープランツ 2026</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月20日（月）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">大型,展示会,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/monster-plants-2nd-marugame-2026.html
+++ b/events/monster-plants-2nd-marugame-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "四国のイベント",
+        "item": "https://agave-navi.com/?region=%E5%9B%9B%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt;
     <span>モンスタープランツ 第2弾</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">綾歌総合文化会館アイレックス</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,珍奇植物</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/must-buy-market-okinawa-2026.html
+++ b/events/must-buy-market-okinawa-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>MUST BUY MARKET!</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">沖縄</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/myoko-taniku-market-13th-2026.html
+++ b/events/myoko-taniku-market-13th-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "北陸のイベント",
+        "item": "https://agave-navi.com/?region=%E5%8C%97%E9%99%B8"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%8C%97%E9%99%B8">北陸のイベント</a> &gt;
     <span>妙高多肉市場 13th</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%8C%97%E9%99%B8" class="detail-back-link">北陸のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">道の駅あらい フィールド妙高</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/nara-botanical-garden-2026.html
+++ b/events/nara-botanical-garden-2026.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>ならの植物園2026</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -161,10 +161,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,展示会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/okibota-spring-2026-sunshine.html
+++ b/events/okibota-spring-2026-sunshine.html
@@ -61,7 +61,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; オキボタ Spring 2026 in サンシャインシティー</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; オキボタ Spring 2026 in サンシャインシティー</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -96,7 +96,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -118,10 +118,6 @@
                     <div class="info-row">
                         <span class="info-label">主催</span>
                         <span class="info-value">合同会社OKIBOTA</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=オキボタ Spring 2026 in サンシャインシティー&dates=20260410%2F20260413&location=東京&details=オキボタ Spring 2026 in サンシャインシティー+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/our-plants-2-03.html
+++ b/events/our-plants-2-03.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; Our Plants ver.2.03</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; Our Plants ver.2.03</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Our Plants ver.2.03&dates=20260425%2F20260426&location=京都&details=Our Plants ver.2.03+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/paludarium-collection-parcole-3rd-2026.html
+++ b/events/paludarium-collection-parcole-3rd-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>第3回 パルダリウムコレクション パルコレ</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">Link! 近畿大学前</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/petit-to-wonder-market-2026.html
+++ b/events/petit-to-wonder-market-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>petit to Wonder Market</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月29日（水）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/picnic-garden-vol20-aobayama-2026.html
+++ b/events/picnic-garden-vol20-aobayama-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>ピクニックガーデン vol.20 in 青葉山公園</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/picnic-garden-vol21-is-new-base-2026.html
+++ b/events/picnic-garden-vol21-is-new-base-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "東北のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E5%8C%97"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt;
     <span>ピクニックガーデン vol.21 in I'S NEW BASE</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">I'S NEW BASE（会津若松市）</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plant-freaks-4th-2026.html
+++ b/events/plant-freaks-4th-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "大型イベント一覧",
-        "item": "https://agave-navi.com/category/large.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/large.html">大型イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>PLANT FREAKS 4th</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">東京</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">大型</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plant-freaks-special-2026-05.html
+++ b/events/plant-freaks-special-2026-05.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>PLANT FREAKS Special</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">オリナス錦糸町</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-2306-3rd-anniversary-2026.html
+++ b/events/plants-2306-3rd-anniversary-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>PLANTS 2306 3rd ANNIVERSARY FESTIVAL</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-fes-vol3-ehime-2026.html
+++ b/events/plants-fes-vol3-ehime-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>PLANTS FES Vol.3</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-fes-vol3.html
+++ b/events/plants-fes-vol3.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "四国のイベント",
+        "item": "https://agave-navi.com/?region=%E5%9B%9B%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt;
     <span>PLANTS FES vol.3</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月19日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-garage-market-2026-spring.html
+++ b/events/plants-garage-market-2026-spring.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>Plants garage market 2026 -SPRING &amp; SUMMER-</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -151,11 +151,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">イリノベ倉庫</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-garage-market-2026-tsukumi.html
+++ b/events/plants-garage-market-2026-tsukumi.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>Plants garage market 2026</span>
   </nav>
 
@@ -135,8 +135,16 @@
           </div>
         </div>
 
+        <div class="detail-section detail-instagram-embed">
+          <h2 class="detail-section-title">Instagram投稿</h2>
+          <div class="instagram-embed-wrap">
+            <iframe src="https://www.instagram.com/reel/DTEIXiekx1D/embed/" loading="lazy" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>
+          </div>
+          <p class="instagram-embed-link"><a href="https://www.instagram.com/reel/DTEIXiekx1D/" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
+        </div>
+
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +158,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">イリノベ倉庫（津久見市）</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-garage-market.html
+++ b/events/plants-garage-market.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>Plants Garage Market</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年5月3日（日） 〜 5月4日（月）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-junkee-12th-2026.html
+++ b/events/plants-junkee-12th-2026.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>プランツジャンキー 12th</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -162,10 +162,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">未定</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,大型</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/plants-plants-plants-2026.html
+++ b/events/plants-plants-plants-2026.html
@@ -116,12 +116,6 @@
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月13日（月）</span>
           </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
-          </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">中部</span>

--- a/events/raflum-popup-nagoya-takashimaya-2026.html
+++ b/events/raflum-popup-nagoya-takashimaya-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "イベント一覧",
+        "item": "https://agave-navi.com/"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/">イベント一覧</a> &gt;
     <span>RAFLUM POP-UP（ジェイアール名古屋タカシマヤ）</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value"></span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/rhythms-of-life-2026.html
+++ b/events/rhythms-of-life-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "東海のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E6%B5%B7"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E6%B5%B7">東海のイベント</a> &gt;
     <span>Rhythms of Life</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">愛知県内</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/saikiengei-fukuyama-marche-2026.html
+++ b/events/saikiengei-fukuyama-marche-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "四国のイベント",
+        "item": "https://agave-navi.com/?region=%E5%9B%9B%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt;
     <span>SaikiEngei to 福山deマルシェ</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">しまなみアースランド</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/seiseihatake-2026.html
+++ b/events/seiseihatake-2026.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>実生畑でつかまえて 2026</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -161,10 +161,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/sendai-agave-shop-vol2.html
+++ b/events/sendai-agave-shop-vol2.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; 仙台竜舌露店 Vol.2</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt; 仙台竜舌露店 Vol.2</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=仙台竜舌露店 Vol.2&dates=20260627%2F20260628&location=宮城&details=仙台竜舌露店 Vol.2+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/shimamura-mini-soransai-2026.html
+++ b/events/shimamura-mini-soransai-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; ミニ草乱祭 in シマムラ園芸</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; ミニ草乱祭 in シマムラ園芸</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -126,10 +126,6 @@
                     <div class="info-row">
                         <span class="info-label">出店数</span>
                         <span class="info-value">40店舗（日替わり出店）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会、マルシェ</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">開催地域</span>

--- a/events/shoku-sai-vol9-izumo-2026.html
+++ b/events/shoku-sai-vol9-izumo-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "中国のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt;
     <span>植祭 vol.9</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">飯塚農園（出雲市）</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/shokubutsu-hyakkaten-2026.html
+++ b/events/shokubutsu-hyakkaten-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>植物百貨展</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">東京都内</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,展示会,大型</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/shokuenseisai-5th.html
+++ b/events/shokuenseisai-5th.html
@@ -70,8 +70,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "四国のイベント",
+        "item": "https://agave-navi.com/?region=%E5%9B%9B%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -103,7 +103,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt;
     <span>植縁祭 5th</span>
   </nav>
 
@@ -143,7 +143,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
         </div>
       </div>
 
@@ -161,10 +161,6 @@
           <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/sippo-de-marche-fukushima-2026.html
+++ b/events/sippo-de-marche-fukushima-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "東北のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E5%8C%97"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt;
     <span>シッポdeマルシェ</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">四季の里 旧農村レストラン</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/sora-to-taiyo-marche-2026.html
+++ b/events/sora-to-taiyo-marche-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>空と太陽のマルシェ</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月12日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/sumi-no-engei-2026-05-02.html
+++ b/events/sumi-no-engei-2026-05-02.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>隅の園藝</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">東京</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/sumi-no-engei-2026-05-09.html
+++ b/events/sumi-no-engei-2026-05-09.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>隅の園藝</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">東京</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/tanifes-vol6-asahikawa-2026.html
+++ b/events/tanifes-vol6-asahikawa-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "北海道のイベント",
+        "item": "https://agave-navi.com/?region=%E5%8C%97%E6%B5%B7%E9%81%93"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%8C%97%E6%B5%B7%E9%81%93">北海道のイベント</a> &gt;
     <span>くうふくあったマルシェ 多肉FESTIVAL VOL.6</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%8C%97%E6%B5%B7%E9%81%93" class="detail-back-link">北海道のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月29日（水）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/taniku-midori-marche-nabana-2026.html
+++ b/events/taniku-midori-marche-nabana-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; 多肉とみどりのマルシェ in なばなの里</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E6%9D%B1%E6%B5%B7">東海のイベント</a> &gt; 多肉とみどりのマルシェ in なばなの里</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
                 </div>
             </div>
 
@@ -122,10 +122,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ、即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">開催回数</span>

--- a/events/taniku-moromoro-2026-spring.html
+++ b/events/taniku-moromoro-2026-spring.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; 多肉もろもろ市場 2026春</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt; 多肉もろもろ市場 2026春</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -91,7 +91,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会、マルシェ</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">公式</span>

--- a/events/tanushimaru-garden-shokuyo-osei-vol4-2026.html
+++ b/events/tanushimaru-garden-shokuyo-osei-vol4-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>田主丸ガーデン植物販売会 植欲旺盛 Vol.4</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">田主丸ガーデン駐車場</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/tenkaichi-2026.html
+++ b/events/tenkaichi-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; 第6回 天下一植物界 BORDER BREAK BEYOND</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt; 第6回 天下一植物界 BORDER BREAK BEYOND</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
                 </div>
             </div>
 
@@ -122,10 +122,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">前売りチケット制（詳細は公式サイト）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">大型イベント、展示会、即売会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">公式</span>

--- a/events/the-botanical-show.html
+++ b/events/the-botanical-show.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>THE BOTANICAL SHOW 5th</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">THE OUTLETS SHONAN HIRATSUKA</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,展示会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/the-plants-episode-9.html
+++ b/events/the-plants-episode-9.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/sokubai.html">即売会イベント一覧</a> &gt; THE PLANTS - Episode 9</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt; THE PLANTS - Episode 9</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+                    <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">即売会</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=THE PLANTS - Episode 9&dates=20260426%2F20260427&location=香川&details=THE PLANTS - Episode 9+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/tilly-fes-vol5-2026.html
+++ b/events/tilly-fes-vol5-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>Tilly FES Vol.5</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月11日（土） 〜 4月12日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,展示会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/tosa-muroto-cactus-8th-2026.html
+++ b/events/tosa-muroto-cactus-8th-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "四国のイベント",
+        "item": "https://agave-navi.com/?region=%E5%9B%9B%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt;
     <span>土佐室戸サボテンクラブ 第八回展示会</span>
   </nav>
 
@@ -135,7 +135,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
         </div>
       </div>
 
@@ -149,11 +149,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">高知県室戸市内会場</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/wakayama-green-marche.html
+++ b/events/wakayama-green-marche.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "マルシェイベント一覧",
-        "item": "https://agave-navi.com/category/marche.html"
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/marche.html">マルシェイベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
     <span>和歌山グリーンマルシェ</span>
   </nav>
 
@@ -136,7 +136,7 @@
         </div>
 
         <div class="detail-back">
-          <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
         </div>
       </div>
 
@@ -150,11 +150,6 @@
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">和歌山</span>
-          </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">マルシェ,即売会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/wasshoi-marche.html
+++ b/events/wasshoi-marche.html
@@ -60,7 +60,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/marche.html">マルシェイベント一覧</a> &gt; わっしょいマルシェ</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt; わっしょいマルシェ</div>
 
     <main class="detail-page">
         <div class="detail-header">
@@ -95,7 +95,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/marche.html" class="detail-back-link">マルシェイベント一覧に戻る</a>
+                    <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
                 </div>
             </div>
 
@@ -113,10 +113,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">マルシェ</span>
                     </div>
                     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=わっしょいマルシェ&dates=20260425%2F20260426&location=岐阜&details=わっしょいマルシェ+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/events/yamaguchi-plants-market-2026.html
+++ b/events/yamaguchi-plants-market-2026.html
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "中国のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E5%9B%BD"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt;
     <span>YAMAGUCHI PLANTS MARKET 2026</span>
   </nav>
 
@@ -130,7 +130,7 @@
 
 
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
         </div>
       </div>
 
@@ -140,12 +140,6 @@
           <div class="info-row">
             <span class="info-label">日時</span>
             <span class="info-value">2026年4月25日（土） 〜 4月26日（日）</span>
-          </div>
-
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,展示会</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>

--- a/events/yokohama-flower-garden-fes-2026.html
+++ b/events/yokohama-flower-garden-fes-2026.html
@@ -62,7 +62,7 @@
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/large.html">大型イベント一覧</a> &gt; 横浜フラワー&ガーデンフェスティバル 2026</div>
+        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; 横浜フラワー&ガーデンフェスティバル 2026</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -100,7 +100,7 @@
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/large.html" class="detail-back-link">大型イベント一覧に戻る</a>
+                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
                 </div>
             </div>
 
@@ -122,10 +122,6 @@
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">前売¥1,600 / 当日¥2,000 / 中学生以下無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">大型、マルシェ、展示会</span>
                     </div>
                     <div class="info-row">
                         <span class="info-label">特徴</span>

--- a/index.html
+++ b/index.html
@@ -1270,7 +1270,7 @@
       <p class="event-description">東京・新宿で開催される春の植物イベント。アガベや多肉植物を含む多彩な植物が集まる展示即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="botanical-circus-7-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1284,7 +1284,7 @@
       <p class="event-description">東京・京橋で開催されるビザールプランツ・珍奇植物の展示即売イベント第7回。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="四国" data-prefecture="愛媛" data-slug="plants-fes-vol3-ehime-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1298,7 +1298,7 @@
       <p class="event-description">愛媛県で開催される多肉植物・アガベの即売イベント第3回。spikybase/MELLOW PLANTS COFFEE主催。</p>
       <div class="event-meta-row"><span class="event-region">愛媛</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="三重" data-slug="plants-2306-3rd-anniversary-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1312,7 +1312,7 @@
       <p class="event-description">三重県で開催されるPLANTS 2306の3周年記念フェスティバル。植物の展示即売会。</p>
       <div class="event-meta-row"><span class="event-region">三重</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,塊根植物" data-status="upcoming" data-region="東海" data-prefecture="愛知" data-slug="jr-takashimaya-raflum-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1326,7 +1326,7 @@
       <p class="event-description">東京の塊根植物・多肉植物専門店RAFLUMのポップアップショップ。レアな塊根植物や鉢の販売。予約不要。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="botanical-botanical-tokyo-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1340,7 +1340,7 @@
       <p class="event-description">東京で開催されるボタニカルイベント。多様な植物愛好家やショップが集まる即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="愛知" data-slug="rhythms-of-life-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1354,7 +1354,7 @@
       <p class="event-description">愛知県で開催される植物イベント。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="マルシェ,即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="greensnap-marche-toyosu-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1368,7 +1368,7 @@
       <p class="event-description">GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="埼玉" data-slug="mini-soransai-june-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1382,7 +1382,7 @@
       <p class="event-description">埼玉県越谷市のシマムラ園芸で開催されるアガベ・多肉植物の即売会。入場無料。</p>
       <div class="event-meta-row"><span class="event-region">埼玉</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="北海道" data-prefecture="北海道" data-slug="haru-saboten-taniku-fair-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1396,7 +1396,7 @@
       <p class="event-description">札幌カクタスクラブ協力による、サボテン・多肉植物の展示販売会。百合が原公園内で開催。</p>
       <div class="event-meta-row"><span class="event-region">北海道</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="四国" data-prefecture="高知" data-slug="tosa-muroto-cactus-8th-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1410,7 +1410,7 @@
       <p class="event-description">土佐室戸サボテンクラブ主催のサボテン・多肉植物展示会。第八回目の開催。</p>
       <div class="event-meta-row"><span class="event-region">高知</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="茨城" data-slug="haze-various-genres-marche-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1424,7 +1424,7 @@
       <p class="event-description">植物を含む多ジャンルのマルシェイベント。アガベ・塊根植物・多肉植物の販売も。</p>
       <div class="event-meta-row"><span class="event-region">茨城</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="静岡" data-slug="fuji-taniku-plants-marche-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1438,7 +1438,7 @@
       <p class="event-description">静岡県富士宮市の啓芳園で開催される多肉植物の即売マルシェ。</p>
       <div class="event-meta-row"><span class="event-region">静岡</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="静岡" data-slug="green-day-vol15-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1452,7 +1452,7 @@
       <p class="event-description">静岡市清水区の日本平運動公園で開催されるグリーン系イベント。多肉植物やアガベなどの即売会。</p>
       <div class="event-meta-row"><span class="event-region">静岡</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="中国" data-prefecture="岡山" data-slug="engei-yaroze-vol11-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1466,7 +1466,7 @@
       <p class="event-description">岡山県赤磐市の熊山英国庭園で開催される植物即売イベント。珍奇植物やアガベ愛好家が集まる。</p>
       <div class="event-meta-row"><span class="event-region">岡山</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="静岡" data-slug="fujiyama-days-little-green-park-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1480,7 +1480,7 @@
       <p class="event-description">静岡県富士市の富士中央公園で開催されるグリーン系マルシェ。植物販売やワークショップを楽しめる。</p>
       <div class="event-meta-row"><span class="event-region">静岡</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関西" data-prefecture="大阪" data-slug="paludarium-collection-parcole-3rd-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1494,7 +1494,7 @@
       <p class="event-description">大阪府東大阪市で開催されるパルダリウム・植物コレクションイベント。珍奇植物やビバリウム関連の販売も。</p>
       <div class="event-meta-row"><span class="event-region">大阪</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="九州" data-prefecture="沖縄" data-slug="chinki-shokubutsu-ichiba-vol8-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1508,7 +1508,7 @@
       <p class="event-description">沖縄で開催される珍奇植物の即売会。アガベ・塊根植物・多肉植物など希少植物が集まる。</p>
       <div class="event-meta-row"><span class="event-region">沖縄</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東北" data-prefecture="秋田" data-slug="botanical-market-akita-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1522,7 +1522,7 @@
       <p class="event-description">秋田県の道の駅うごで開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。</p>
       <div class="event-meta-row"><span class="event-region">秋田</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="chinki-shokubutsu-freemarket-machida-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1536,7 +1536,7 @@
       <p class="event-description">東京都町田市のパリオで開催される珍奇植物のフリーマーケット。アガベや塊根植物の個人売買が楽しめる。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="九州" data-prefecture="福岡" data-slug="fukutomo-marche-3-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1550,7 +1550,7 @@
       <p class="event-description">多肉植物・アガベ・ティランジアなどの植物と雑貨の即売会。出店者による交換会や特別苗の抽選販売も実施。</p>
       <div class="event-meta-row"><span class="event-region">福岡</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="plant-freaks-special-2026-05">
     <div class="event-thumb event-no-image"></div>
@@ -1564,7 +1564,7 @@
       <p class="event-description">塊根植物やアガベを中心とした珍奇植物の即売会。東京・錦糸町で開催されるPLANT FREAKSのスペシャル版。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="関東" data-prefecture="千葉" data-slug="coco-et-nico-bond-project-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1578,7 +1578,7 @@
       <p class="event-description">ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。</p>
       <div class="event-meta-row"><span class="event-region">千葉</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="展示会,即売会" data-status="upcoming" data-region="北陸" data-prefecture="富山" data-slug="haru-cactus-succulent-kuro-toyama-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1592,7 +1592,7 @@
       <p class="event-description">富山県中央植物園で開催される春のサボテン・多肉植物展。特別展示「黒」をテーマにした展示即売会。</p>
       <div class="event-meta-row"><span class="event-region">富山</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="九州" data-prefecture="福岡" data-slug="tanushimaru-garden-shokuyo-osei-vol4-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1606,7 +1606,7 @@
       <p class="event-description">福岡県久留米市・田主丸ガーデンで開催される植物販売会。アガベ・多肉植物・珍奇植物の即売イベント。</p>
       <div class="event-meta-row"><span class="event-region">福岡</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="マルシェ" data-status="upcoming" data-region="東北" data-prefecture="福島" data-slug="sippo-de-marche-fukushima-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1620,7 +1620,7 @@
       <p class="event-description">福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。</p>
       <div class="event-meta-row"><span class="event-region">福島</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="マルシェ,即売会" data-status="upcoming" data-region="東北" data-prefecture="宮城" data-slug="picnic-garden-vol20-aobayama-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1634,7 +1634,7 @@
       <p class="event-description">宮城県仙台市・青葉山公園で開催される植物マルシェ第20回。多肉植物・観葉植物・雑貨が集まる。</p>
       <div class="event-meta-row"><span class="event-region">宮城</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="中国" data-prefecture="島根" data-slug="shoku-sai-vol9-izumo-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1648,7 +1648,7 @@
       <p class="event-description">島根県出雲市・飯塚農園で開催される植物イベント第9回。多肉植物やアガベの即売会。</p>
       <div class="event-meta-row"><span class="event-region">島根</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="マルシェ,即売会" data-status="upcoming" data-region="東北" data-prefecture="福島" data-slug="picnic-garden-vol21-is-new-base-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1662,7 +1662,7 @@
       <p class="event-description">福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。</p>
       <div class="event-meta-row"><span class="event-region">福島</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="マルシェ,即売会" data-status="upcoming" data-region="四国" data-prefecture="愛媛" data-slug="saikiengei-fukuyama-marche-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1676,7 +1676,7 @@
       <p class="event-description">愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。</p>
       <div class="event-meta-row"><span class="event-region">愛媛</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関西" data-prefecture="京都" data-slug="botanic-bomb-10th-kyoto-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1690,7 +1690,7 @@
       <p class="event-description">京都府福知山市・三段池公園で開催される植物イベント第10回。アガベ・多肉・珍奇植物が集まる即売会。</p>
       <div class="event-meta-row"><span class="event-region">京都</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="愛知" data-slug="raflum-popup-nagoya-takashimaya-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1704,7 +1704,7 @@
       <p class="event-description">ジェイアール名古屋タカシマヤで開催されるRAFLUMのポップアップストア。多肉植物・珍奇植物の展示販売。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="北海道" data-prefecture="北海道" data-slug="haru-saboten-taniku-fair-sapporo-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1718,7 +1718,7 @@
       <p class="event-description">札幌市で開催される春のサボテン・多肉植物フェア。3日間にわたりサボテン・多肉植物の即売会を実施。</p>
       <div class="event-meta-row"><span class="event-region">北海道</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="大型,即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="isij-big-bazaar-2026-05-24">
     <div class="event-thumb event-no-image"></div>
@@ -1732,7 +1732,7 @@
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="大型,即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="isij-big-bazaar-2026-07-12">
     <div class="event-thumb event-no-image"></div>
@@ -1746,7 +1746,7 @@
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="大型,即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="isij-big-bazaar-2026-09-27">
     <div class="event-thumb event-no-image"></div>
@@ -1760,7 +1760,7 @@
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="大型,即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="isij-big-bazaar-2026-11-22">
     <div class="event-thumb event-no-image"></div>
@@ -1774,7 +1774,7 @@
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="関西" data-prefecture="大阪" data-slug="hosokawa-botafes-2026-spring">
     <div class="event-thumb event-no-image"></div>
@@ -1788,7 +1788,7 @@
       <p class="event-description">大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。</p>
       <div class="event-meta-row"><span class="event-region">大阪</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="北陸" data-prefecture="新潟" data-slug="myoko-taniku-market-13th-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1802,7 +1802,7 @@
       <p class="event-description">新潟県妙高市・道の駅あらいで毎月開催される多肉植物の即売会第13回。県内外の栽培家や園芸愛好家による多肉植物・雑貨販売とキッチンカーが集結。</p>
       <div class="event-meta-row"><span class="event-region">新潟</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="九州" data-prefecture="福岡" data-slug="fukuoka-green-party-6th-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1816,7 +1816,7 @@
       <p class="event-description">福岡県糸島市・志摩中央公園で開催されるアガベ・塊根植物・珍奇植物の即売会。10:00〜16:00開催。GW期間中の九州最大級の植物イベント。</p>
       <div class="event-meta-row"><span class="event-region">福岡</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="大型,即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="gotanda-big-bazaar-2026-05">
     <div class="event-thumb event-no-image"></div>
@@ -1830,7 +1830,7 @@
       <p class="event-description">ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="九州" data-prefecture="大分" data-slug="plants-garage-market-2026-tsukumi">
     <div class="event-thumb event-no-image"></div>
@@ -1844,7 +1844,7 @@
       <p class="event-description">大分県津久見市・イリノベ倉庫で開催される植物即売会。塊根植物・アガベ・ビカクシダなど珍しい植物や植物関連雑貨を扱う店舗が集結。Oita Plants Farmとvandaka plantsの共同開催。</p>
       <div class="event-meta-row"><span class="event-region">大分</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="東海" data-prefecture="愛知" data-slug="aichin-shokusai-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1858,7 +1858,7 @@
       <p class="event-description">珍奇植物・アガベ・塊根植物などビザールプランツが集結する刈谷の植物即売会。入場無料・刈谷駅から徒歩圏内。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="九州" data-prefecture="大分" data-slug="plants-garage-market-2026-spring">
     <div class="event-thumb event-no-image"></div>
@@ -1872,7 +1872,7 @@
       <p class="event-description">大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。</p>
       <div class="event-meta-row"><span class="event-region">大分</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="sumi-no-engei-2026-05-02">
     <div class="event-thumb event-no-image"></div>
@@ -1886,7 +1886,7 @@
       <p class="event-description">東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="sumi-no-engei-2026-05-09">
     <div class="event-thumb event-no-image"></div>
@@ -1900,7 +1900,7 @@
       <p class="event-description">東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関西" data-prefecture="和歌山" data-slug="haru-saboten-wakayama-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1914,7 +1914,7 @@
       <p class="event-description">和歌山で開催される春のサボテン即売会。</p>
       <div class="event-meta-row"><span class="event-region">和歌山</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="関東" data-prefecture="東京" data-slug="jiyugaoka-botanical-market-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1928,7 +1928,7 @@
       <p class="event-description">自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関西" data-prefecture="大阪" data-slug="grateful-days-10th-osaka-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1942,7 +1942,7 @@
       <p class="event-description">大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。</p>
       <div class="event-meta-row"><span class="event-region">大阪</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="九州" data-prefecture="沖縄" data-slug="must-buy-market-okinawa-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1956,7 +1956,7 @@
       <p class="event-description">沖縄で開催される植物販売マーケット。</p>
       <div class="event-meta-row"><span class="event-region">沖縄</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会,マルシェ" data-status="upcoming" data-region="東北" data-prefecture="岩手" data-slug="iwate-hana-midori-matsuri-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1970,7 +1970,7 @@
       <p class="event-description">岩手で開催される花と緑の祭り。植物販売会。</p>
       <div class="event-meta-row"><span class="event-region">岩手</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     <div class="event-card" data-tags="即売会" data-status="upcoming" data-region="関西" data-prefecture="兵庫" data-slug="himeji-kisotengai-shokubutsuichi-2026">
     <div class="event-thumb event-no-image"></div>
@@ -1984,7 +1984,7 @@
       <p class="event-description">姫路城で開催される珍奇植物の即売会。アガベ・塊根植物等を販売。</p>
       <div class="event-meta-row"><span class="event-region">兵庫</span></div>
     </div>
-    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
+    <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg><span>行きたい</span></div>
   </div>
     </div><!-- /eventsGrid -->
 

--- a/index.html
+++ b/index.html
@@ -141,14 +141,7 @@
 
     <div class="filter-bar">
         <div class="filter-bar-inner">
-            <div class="filter-tabs">
-                <button class="filter-tab active" onclick="filterEvents('all')">すべて</button>
-                <button class="filter-tab" onclick="filterEvents('即売会')">即売会</button>
-                <button class="filter-tab" onclick="filterEvents('マルシェ')">マルシェ</button>
-                <button class="filter-tab" onclick="filterEvents('大型')">大型イベント</button>
-                <button class="filter-tab" onclick="filterEvents('展示会')">展示会</button>
-            </div>
-<div class="filter-controls">
+            <div class="filter-controls">
                 <select id="sortOrder" class="filter-select" onchange="sortAndFilter()">
                     <option value="date-asc">開催日が近い順</option>
                     <option value="date-desc">開催日が遠い順</option>
@@ -212,10 +205,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">埼玉</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/bizarrefarm-spring-fes-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -236,11 +225,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">奈良</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">展示会</span>
-                        </div>
-                        <a href="events/nara-botanical-garden-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -261,11 +245,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大阪</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">大型</span>
-                        </div>
-                        <a href="events/botanical-botanical-osaka.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -286,11 +265,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">和歌山</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/wakayama-green-marche.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -311,11 +285,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">和歌山</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/bota-magic-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -337,10 +306,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">千葉</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/joyful-festival-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -361,11 +326,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">神奈川</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">展示会</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/the-botanical-show.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -386,12 +346,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">東京</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">展示会</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/futakotamagawa-botanical-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -412,10 +366,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">東京</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/seiseihatake-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -436,11 +386,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">愛媛</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/shokuenseisai-5th.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -461,11 +406,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大阪</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">大型</span>
-                        </div>
-                        <a href="events/plants-junkee-12th-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -486,10 +426,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">東京</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/bromeliad-festa-spring-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -510,11 +446,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">三重</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/taniku-midori-marche-nabana-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -535,10 +466,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">東京</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/okibota-spring-2026-sunshine.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -559,11 +486,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">兵庫</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/hanauchu-dream-garden-26.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -584,11 +506,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">愛知</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">大型</span>
-                        </div>
-                        <a href="events/iku-matsuri-ichinomiya-spring.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -609,11 +526,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">東京</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">展示会</span>
-                        </div>
-                        <a href="events/tilly-fes-vol5-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -634,12 +546,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">神奈川</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">大型</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/greensnap-marche-yokohama-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -660,10 +566,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">茨城</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/sora-to-taiyo-marche-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -684,10 +586,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">兵庫</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/agave-meeting-2026-kobe.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -708,10 +606,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">埼玉</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/jungle-plants-market.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -732,10 +626,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">岐阜</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/plants-plants-plants-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -756,11 +646,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">兵庫</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/taniku-moromoro-2026-spring.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -781,10 +666,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大分</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/bts-beppu-taniku-show-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -805,11 +686,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">埼玉</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/shimamura-mini-soransai-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -830,11 +706,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">愛媛</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/plants-fes-vol3.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -855,12 +726,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">東京</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">展示会</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/monster-plants-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -881,11 +746,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">山口</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">展示会</span>
-                        </div>
-                        <a href="events/yamaguchi-plants-market-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -906,10 +766,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大阪</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/fumakilla-kadan-fes-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -930,10 +786,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">京都</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/our-plants-2-03.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -954,10 +806,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">岐阜</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/wasshoi-marche.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -978,11 +826,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">愛知</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">大型</span>
-                        </div>
-                        <a href="events/aichi-plants-fes-vol1.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1003,10 +846,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">岡山</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/hobby-plants-freaks-vol5.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1027,10 +866,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">千葉</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/kisarazu-cs-fair.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1051,10 +886,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">香川</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/the-plants-episode-9.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1075,10 +906,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">埼玉</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/petit-to-wonder-market-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1099,11 +926,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大阪</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/hanatomofesta-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1124,11 +946,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">北海道</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/tanifes-vol6-asahikawa-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1152,12 +969,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">神奈川</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">展示会</span>
-                        </div>
-                        <a href="events/yokohama-flower-garden-fes-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1178,11 +989,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大分</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/plants-garage-market.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1203,11 +1009,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">福岡</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/fukuoka-green-party-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1228,11 +1029,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">静岡</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">大型</span>
-                        </div>
-                        <a href="events/fujisan-festa.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1253,11 +1049,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">熊本</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/collect-plants-vol2.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1278,10 +1069,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">石川</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/botanical-marche-kanazawa-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1302,10 +1089,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">京都</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/fushimi-daisakusen-vol2.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1326,12 +1109,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大阪</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">展示会</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/tenkaichi-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1352,12 +1129,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">大阪</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">大型</span>
-                            <span class="tag">即売会</span>
-                            <span class="tag">展示会</span>
-                        </div>
-                        <a href="events/border-break-6th-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1378,11 +1149,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">広島</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/greensnap-marche-hiroshima-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1403,11 +1169,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">栃木</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                            <span class="tag">大型</span>
-                        </div>
-                        <a href="events/iku-matsuri-utsunomiya-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1428,11 +1189,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">和歌山</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/green-breeze-fes-vol3.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1454,10 +1210,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">宮城</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">マルシェ</span>
-                        </div>
-                        <a href="events/sendai-agave-shop-vol2.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1479,10 +1231,6 @@
                         <div class="event-meta-row">
                             <span class="event-region">神奈川</span>
                         </div>
-                        <div class="event-tags">
-                            <span class="tag">即売会</span>
-                        </div>
-                        <a href="events/happy-smile-odawara-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1495,7 +1243,6 @@
 <h3 class="event-title">モンスタープランツ 第2弾</h3>
 <p class="event-description">香川県丸亀市で開催される珍奇植物販売会。入場無料。</p>
 <div class="event-meta-row"><span class="event-region">香川</span></div>
-<a href="events/monster-plants-2nd-marugame-2026.html" class="event-link">詳細を見る</a>
 </div>
 <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1508,7 +1255,6 @@
 <h3 class="event-title">植物百貨展</h3>
 <p class="event-description">東京で開催される大型植物展示即売会。</p>
 <div class="event-meta-row"><span class="event-region">東京</span></div>
-<a href="events/shokubutsu-hyakkaten-2026.html" class="event-link">詳細を見る</a>
 </div>
 <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -1523,7 +1269,6 @@
       <h3 class="event-title">芽吹祭</h3>
       <p class="event-description">東京・新宿で開催される春の植物イベント。アガベや多肉植物を含む多彩な植物が集まる展示即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/mebuki-sai-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1538,7 +1283,6 @@
       <h3 class="event-title">Botanical Circus 7</h3>
       <p class="event-description">東京・京橋で開催されるビザールプランツ・珍奇植物の展示即売イベント第7回。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/botanical-circus-7-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1553,7 +1297,6 @@
       <h3 class="event-title">PLANTS FES Vol.3</h3>
       <p class="event-description">愛媛県で開催される多肉植物・アガベの即売イベント第3回。spikybase/MELLOW PLANTS COFFEE主催。</p>
       <div class="event-meta-row"><span class="event-region">愛媛</span></div>
-      <a href="events/plants-fes-vol3-ehime-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1568,7 +1311,6 @@
       <h3 class="event-title">PLANTS 2306 3rd ANNIVERSARY FESTIVAL</h3>
       <p class="event-description">三重県で開催されるPLANTS 2306の3周年記念フェスティバル。植物の展示即売会。</p>
       <div class="event-meta-row"><span class="event-region">三重</span></div>
-      <a href="events/plants-2306-3rd-anniversary-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1583,7 +1325,6 @@
       <h3 class="event-title">JR名古屋タカシマヤ × RAFLUM ポップアップ</h3>
       <p class="event-description">東京の塊根植物・多肉植物専門店RAFLUMのポップアップショップ。レアな塊根植物や鉢の販売。予約不要。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
-      <a href="events/jr-takashimaya-raflum-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1598,7 +1339,6 @@
       <h3 class="event-title">BOTANICAL BOTANICAL TOKYO</h3>
       <p class="event-description">東京で開催されるボタニカルイベント。多様な植物愛好家やショップが集まる即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/botanical-botanical-tokyo-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1613,7 +1353,6 @@
       <h3 class="event-title">Rhythms of Life</h3>
       <p class="event-description">愛知県で開催される植物イベント。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
-      <a href="events/rhythms-of-life-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1628,7 +1367,6 @@
       <h3 class="event-title">GreenSnap Marche 豊洲 2026</h3>
       <p class="event-description">GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/greensnap-marche-toyosu-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1643,7 +1381,6 @@
       <h3 class="event-title">ミニ草乱祭（6月）</h3>
       <p class="event-description">埼玉県越谷市のシマムラ園芸で開催されるアガベ・多肉植物の即売会。入場無料。</p>
       <div class="event-meta-row"><span class="event-region">埼玉</span></div>
-      <a href="events/mini-soransai-june-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1658,7 +1395,6 @@
       <h3 class="event-title">春のサボテン多肉植物フェア</h3>
       <p class="event-description">札幌カクタスクラブ協力による、サボテン・多肉植物の展示販売会。百合が原公園内で開催。</p>
       <div class="event-meta-row"><span class="event-region">北海道</span></div>
-      <a href="events/haru-saboten-taniku-fair-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1673,7 +1409,6 @@
       <h3 class="event-title">土佐室戸サボテンクラブ 第八回展示会</h3>
       <p class="event-description">土佐室戸サボテンクラブ主催のサボテン・多肉植物展示会。第八回目の開催。</p>
       <div class="event-meta-row"><span class="event-region">高知</span></div>
-      <a href="events/tosa-muroto-cactus-8th-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1688,7 +1423,6 @@
       <h3 class="event-title">HAZE -various genres marche</h3>
       <p class="event-description">植物を含む多ジャンルのマルシェイベント。アガベ・塊根植物・多肉植物の販売も。</p>
       <div class="event-meta-row"><span class="event-region">茨城</span></div>
-      <a href="events/haze-various-genres-marche-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1703,7 +1437,6 @@
       <h3 class="event-title">富士多肉プランツマルシェ</h3>
       <p class="event-description">静岡県富士宮市の啓芳園で開催される多肉植物の即売マルシェ。</p>
       <div class="event-meta-row"><span class="event-region">静岡</span></div>
-      <a href="events/fuji-taniku-plants-marche-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1718,7 +1451,6 @@
       <h3 class="event-title">Green Day vol.15</h3>
       <p class="event-description">静岡市清水区の日本平運動公園で開催されるグリーン系イベント。多肉植物やアガベなどの即売会。</p>
       <div class="event-meta-row"><span class="event-region">静岡</span></div>
-      <a href="events/green-day-vol15-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1733,7 +1465,6 @@
       <h3 class="event-title">園藝野郎勢 Vol.11 2026 春の陣</h3>
       <p class="event-description">岡山県赤磐市の熊山英国庭園で開催される植物即売イベント。珍奇植物やアガベ愛好家が集まる。</p>
       <div class="event-meta-row"><span class="event-region">岡山</span></div>
-      <a href="events/engei-yaroze-vol11-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1748,7 +1479,6 @@
       <h3 class="event-title">FUJIYAMA DAYS LITTLE GREEN PARK</h3>
       <p class="event-description">静岡県富士市の富士中央公園で開催されるグリーン系マルシェ。植物販売やワークショップを楽しめる。</p>
       <div class="event-meta-row"><span class="event-region">静岡</span></div>
-      <a href="events/fujiyama-days-little-green-park-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1763,7 +1493,6 @@
       <h3 class="event-title">第3回 パルダリウムコレクション パルコレ</h3>
       <p class="event-description">大阪府東大阪市で開催されるパルダリウム・植物コレクションイベント。珍奇植物やビバリウム関連の販売も。</p>
       <div class="event-meta-row"><span class="event-region">大阪</span></div>
-      <a href="events/paludarium-collection-parcole-3rd-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1778,7 +1507,6 @@
       <h3 class="event-title">珍奇植物市場 Vol.8</h3>
       <p class="event-description">沖縄で開催される珍奇植物の即売会。アガベ・塊根植物・多肉植物など希少植物が集まる。</p>
       <div class="event-meta-row"><span class="event-region">沖縄</span></div>
-      <a href="events/chinki-shokubutsu-ichiba-vol8-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1793,7 +1521,6 @@
       <h3 class="event-title">ボタニカルマーケット</h3>
       <p class="event-description">秋田県の道の駅うごで開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。</p>
       <div class="event-meta-row"><span class="event-region">秋田</span></div>
-      <a href="events/botanical-market-akita-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1808,7 +1535,6 @@
       <h3 class="event-title">珍奇植物フリーマーケット</h3>
       <p class="event-description">東京都町田市のパリオで開催される珍奇植物のフリーマーケット。アガベや塊根植物の個人売買が楽しめる。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/chinki-shokubutsu-freemarket-machida-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1823,7 +1549,6 @@
       <h3 class="event-title">第3回 福友マルシェ</h3>
       <p class="event-description">多肉植物・アガベ・ティランジアなどの植物と雑貨の即売会。出店者による交換会や特別苗の抽選販売も実施。</p>
       <div class="event-meta-row"><span class="event-region">福岡</span></div>
-      <a href="events/fukutomo-marche-3-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1838,7 +1563,6 @@
       <h3 class="event-title">PLANT FREAKS Special</h3>
       <p class="event-description">塊根植物やアガベを中心とした珍奇植物の即売会。東京・錦糸町で開催されるPLANT FREAKSのスペシャル版。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/plant-freaks-special-2026-05.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1853,7 +1577,6 @@
       <h3 class="event-title">COCO ET NICO presents Bond PROJECT</h3>
       <p class="event-description">ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。</p>
       <div class="event-meta-row"><span class="event-region">千葉</span></div>
-      <a href="events/coco-et-nico-bond-project-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1868,7 +1591,6 @@
       <h3 class="event-title">春のサボテン・多肉植物展 ―特別展示 黒―</h3>
       <p class="event-description">富山県中央植物園で開催される春のサボテン・多肉植物展。特別展示「黒」をテーマにした展示即売会。</p>
       <div class="event-meta-row"><span class="event-region">富山</span></div>
-      <a href="events/haru-cactus-succulent-kuro-toyama-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1883,7 +1605,6 @@
       <h3 class="event-title">田主丸ガーデン植物販売会 植欲旺盛 Vol.4</h3>
       <p class="event-description">福岡県久留米市・田主丸ガーデンで開催される植物販売会。アガベ・多肉植物・珍奇植物の即売イベント。</p>
       <div class="event-meta-row"><span class="event-region">福岡</span></div>
-      <a href="events/tanushimaru-garden-shokuyo-osei-vol4-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1898,7 +1619,6 @@
       <h3 class="event-title">シッポdeマルシェ</h3>
       <p class="event-description">福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。</p>
       <div class="event-meta-row"><span class="event-region">福島</span></div>
-      <a href="events/sippo-de-marche-fukushima-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1913,7 +1633,6 @@
       <h3 class="event-title">ピクニックガーデン vol.20 in 青葉山公園</h3>
       <p class="event-description">宮城県仙台市・青葉山公園で開催される植物マルシェ第20回。多肉植物・観葉植物・雑貨が集まる。</p>
       <div class="event-meta-row"><span class="event-region">宮城</span></div>
-      <a href="events/picnic-garden-vol20-aobayama-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1928,7 +1647,6 @@
       <h3 class="event-title">植祭 vol.9</h3>
       <p class="event-description">島根県出雲市・飯塚農園で開催される植物イベント第9回。多肉植物やアガベの即売会。</p>
       <div class="event-meta-row"><span class="event-region">島根</span></div>
-      <a href="events/shoku-sai-vol9-izumo-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1943,7 +1661,6 @@
       <h3 class="event-title">ピクニックガーデン vol.21 in I'S NEW BASE</h3>
       <p class="event-description">福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。</p>
       <div class="event-meta-row"><span class="event-region">福島</span></div>
-      <a href="events/picnic-garden-vol21-is-new-base-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1958,7 +1675,6 @@
       <h3 class="event-title">SaikiEngei to 福山deマルシェ</h3>
       <p class="event-description">愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。</p>
       <div class="event-meta-row"><span class="event-region">愛媛</span></div>
-      <a href="events/saikiengei-fukuyama-marche-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1973,7 +1689,6 @@
       <h3 class="event-title">BOTANIC BOMB 10TH（ボタニックボム）</h3>
       <p class="event-description">京都府福知山市・三段池公園で開催される植物イベント第10回。アガベ・多肉・珍奇植物が集まる即売会。</p>
       <div class="event-meta-row"><span class="event-region">京都</span></div>
-      <a href="events/botanic-bomb-10th-kyoto-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -1988,7 +1703,6 @@
       <h3 class="event-title">RAFLUM POP-UP（ジェイアール名古屋タカシマヤ）</h3>
       <p class="event-description">ジェイアール名古屋タカシマヤで開催されるRAFLUMのポップアップストア。多肉植物・珍奇植物の展示販売。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
-      <a href="events/raflum-popup-nagoya-takashimaya-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2003,7 +1717,6 @@
       <h3 class="event-title">春のサボテン多肉植物フェア</h3>
       <p class="event-description">札幌市で開催される春のサボテン・多肉植物フェア。3日間にわたりサボテン・多肉植物の即売会を実施。</p>
       <div class="event-meta-row"><span class="event-region">北海道</span></div>
-      <a href="events/haru-saboten-taniku-fair-sapporo-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2018,7 +1731,6 @@
       <h3 class="event-title">5月のサボテン・多肉植物ビッグバザール</h3>
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/isij-big-bazaar-2026-05-24.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2033,7 +1745,6 @@
       <h3 class="event-title">7月のサボテン・多肉植物ビッグバザール</h3>
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/isij-big-bazaar-2026-07-12.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2048,7 +1759,6 @@
       <h3 class="event-title">9月のサボテン・多肉植物ビッグバザール</h3>
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/isij-big-bazaar-2026-09-27.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2063,7 +1773,6 @@
       <h3 class="event-title">11月のサボテン・多肉植物ビッグバザール</h3>
       <p class="event-description">ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/isij-big-bazaar-2026-11-22.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2078,7 +1787,6 @@
       <h3 class="event-title">HOSOKAWA BOTAFES '26 spring</h3>
       <p class="event-description">大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。</p>
       <div class="event-meta-row"><span class="event-region">大阪</span></div>
-      <a href="events/hosokawa-botafes-2026-spring.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2093,7 +1801,6 @@
       <h3 class="event-title">妙高多肉市場 13th</h3>
       <p class="event-description">新潟県妙高市・道の駅あらいで毎月開催される多肉植物の即売会第13回。県内外の栽培家や園芸愛好家による多肉植物・雑貨販売とキッチンカーが集結。</p>
       <div class="event-meta-row"><span class="event-region">新潟</span></div>
-      <a href="events/myoko-taniku-market-13th-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2108,7 +1815,6 @@
       <h3 class="event-title">第6回 福岡グリーンパーティー</h3>
       <p class="event-description">福岡県糸島市・志摩中央公園で開催されるアガベ・塊根植物・珍奇植物の即売会。10:00〜16:00開催。GW期間中の九州最大級の植物イベント。</p>
       <div class="event-meta-row"><span class="event-region">福岡</span></div>
-      <a href="events/fukuoka-green-party-6th-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2123,7 +1829,6 @@
       <h3 class="event-title">サボテン・多肉植物ビッグバザール</h3>
       <p class="event-description">ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/gotanda-big-bazaar-2026-05.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2138,7 +1843,6 @@
       <h3 class="event-title">Plants garage market 2026</h3>
       <p class="event-description">大分県津久見市・イリノベ倉庫で開催される植物即売会。塊根植物・アガベ・ビカクシダなど珍しい植物や植物関連雑貨を扱う店舗が集結。Oita Plants Farmとvandaka plantsの共同開催。</p>
       <div class="event-meta-row"><span class="event-region">大分</span></div>
-      <a href="events/plants-garage-market-2026-tsukumi.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2153,7 +1857,6 @@
       <h3 class="event-title">愛珍植祭2026</h3>
       <p class="event-description">珍奇植物・アガベ・塊根植物などビザールプランツが集結する刈谷の植物即売会。入場無料・刈谷駅から徒歩圏内。</p>
       <div class="event-meta-row"><span class="event-region">愛知</span></div>
-      <a href="events/aichin-shokusai-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2168,7 +1871,6 @@
       <h3 class="event-title">Plants garage market 2026 -SPRING & SUMMER-</h3>
       <p class="event-description">大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。</p>
       <div class="event-meta-row"><span class="event-region">大分</span></div>
-      <a href="events/plants-garage-market-2026-spring.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2183,7 +1885,6 @@
       <h3 class="event-title">隅の園藝</h3>
       <p class="event-description">東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/sumi-no-engei-2026-05-02.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2198,7 +1899,6 @@
       <h3 class="event-title">隅の園藝</h3>
       <p class="event-description">東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/sumi-no-engei-2026-05-09.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2213,7 +1913,6 @@
       <h3 class="event-title">春のサボテン即売会</h3>
       <p class="event-description">和歌山で開催される春のサボテン即売会。</p>
       <div class="event-meta-row"><span class="event-region">和歌山</span></div>
-      <a href="events/haru-saboten-wakayama-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2228,7 +1927,6 @@
       <h3 class="event-title">Jiyugaoka Botanical Market</h3>
       <p class="event-description">自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。</p>
       <div class="event-meta-row"><span class="event-region">東京</span></div>
-      <a href="events/jiyugaoka-botanical-market-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2243,7 +1941,6 @@
       <h3 class="event-title">Grateful Days 〜 The 10th episode 〜</h3>
       <p class="event-description">大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。</p>
       <div class="event-meta-row"><span class="event-region">大阪</span></div>
-      <a href="events/grateful-days-10th-osaka-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2258,7 +1955,6 @@
       <h3 class="event-title">MUST BUY MARKET!</h3>
       <p class="event-description">沖縄で開催される植物販売マーケット。</p>
       <div class="event-meta-row"><span class="event-region">沖縄</span></div>
-      <a href="events/must-buy-market-okinawa-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2273,7 +1969,6 @@
       <h3 class="event-title">花と緑のまつり</h3>
       <p class="event-description">岩手で開催される花と緑の祭り。植物販売会。</p>
       <div class="event-meta-row"><span class="event-region">岩手</span></div>
-      <a href="events/iwate-hana-midori-matsuri-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2288,7 +1983,6 @@
       <h3 class="event-title">姫路城 奇草天外な植物市</h3>
       <p class="event-description">姫路城で開催される珍奇植物の即売会。アガベ・塊根植物等を販売。</p>
       <div class="event-meta-row"><span class="event-region">兵庫</span></div>
-      <a href="events/himeji-kisotengai-shokubutsuichi-2026.html" class="event-link">詳細を見る →</a>
     </div>
     <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg></div>
   </div>
@@ -2318,7 +2012,6 @@
                         <h3 class="event-title">第2回 熊谷多肉フェス</h3>
                         <p class="event-description">埼玉県で開催された多肉植物の専門マーケット。</p>
                         <div class="event-meta-row"><span class="event-region">埼玉</span></div>
-                        <a href="events/kumagaya-taniku-fes-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -2337,7 +2030,6 @@
                         <h3 class="event-title">MIYASHITA PARK Pop-Up Store</h3>
                         <p class="event-description">渋谷の大型商業施設での期間限定ポップアップストア。</p>
                         <div class="event-meta-row"><span class="event-region">東京</span></div>
-                        <a href="events/miyashita-park-popup-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -2356,7 +2048,6 @@
                         <h3 class="event-title">いばらきスカイパレット 植物マルシェ</h3>
                         <p class="event-description">茨城県の屋外施設で開催された植物マーケット。</p>
                         <div class="event-meta-row"><span class="event-region">茨城</span></div>
-                        <a href="events/ibaraki-sky-palette-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -2375,7 +2066,6 @@
                         <h3 class="event-title">PLANT FREAKS 4th</h3>
                         <p class="event-description">植物好きのための大型フェスティバル。</p>
                         <div class="event-meta-row"><span class="event-region">東京</span></div>
-                        <a href="events/plant-freaks-4th-2026.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -2446,12 +2136,13 @@
             });
         });
 
-        // Make entire event card clickable
-        document.querySelectorAll('.event-card:not(.event-ended)').forEach(card => {
+        // Make entire event card clickable (navigates by data-slug)
+        document.querySelectorAll('.event-card[data-slug]:not(.event-ended)').forEach(card => {
+            card.style.cursor = 'pointer';
             card.addEventListener('click', function(e) {
-                if (e.target.tagName === 'A') return;
-                const link = this.querySelector('.event-link');
-                if (link) window.location.href = link.href;
+                if (e.target.closest('a, button, .card-fav-bar, .fav-btn')) return;
+                const slug = this.getAttribute('data-slug');
+                if (slug) window.location.href = 'events/' + slug + '.html';
             });
         });
 

--- a/scripts/generate_event_page.py
+++ b/scripts/generate_event_page.py
@@ -118,15 +118,13 @@ def generate_detail_page(data):
     maps_embed = make_maps_embed(address)
     meta_desc = description[:120] if len(description) > 120 else description
 
-    # カテゴリからパンくず用のカテゴリスラッグを推定
-    cat_map = {
-        '即売会': ('sokubaikai', '即売会一覧'),
-        '大型': ('large', '大型イベント一覧'),
-        'マルシェ': ('marche', 'マルシェ一覧'),
-        '展示会': ('exhibition', '展示会一覧'),
-    }
-    primary_cat = category.split(',')[0].strip() if ',' in category else category
-    cat_slug, cat_label = cat_map.get(primary_cat, ('sokubaikai', '即売会一覧'))
+    # エリア（地域）ベースのパンくず
+    if region:
+        area_label = f'{region}のイベント'
+        area_href = f'/?region={urllib.parse.quote(region)}'
+    else:
+        area_label = 'イベント一覧'
+        area_href = '/'
 
     # 構造化データ用の日時
     start_iso = f'{date_str}T10:00:00+09:00'
@@ -203,7 +201,7 @@ def generate_detail_page(data):
     </nav>
 
     <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="../category/{cat_slug}.html">{cat_label}</a> &gt; {name}</div>
+        <a href="/">ホーム</a> &gt; <a href="{area_href}">{area_label}</a> &gt; {name}</div>
 
     <main class="detail-page">
         <div class="detail-hero">
@@ -239,7 +237,7 @@ def generate_detail_page(data):
                 </div>
 
                 <div class="detail-back">
-                    <a href="../category/{cat_slug}.html" class="detail-back-link">{cat_label}に戻る</a>
+                    <a href="{area_href}" class="detail-back-link">{area_label}に戻る</a>
                 </div>
             </div>
 
@@ -261,10 +259,6 @@ def generate_detail_page(data):
                     <div class="info-row">
                         <span class="info-label">入場料</span>
                         <span class="info-value">{admission}</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">カテゴリ</span>
-                        <span class="info-value">{tags}</span>
                     </div>'''
 
     if official_url:
@@ -435,8 +429,6 @@ def generate_index_card(data, slug):
     short_pref = get_short_pref(prefecture or address)
     short_desc = description[:80] + '...' if len(description) > 80 else description
 
-    tag_items = ''.join(f'<span class="tag">{t.strip()}</span>' for t in tags.split(','))
-
     card = f'''
                     <div class="event-card" data-tags="{tags}" data-status="upcoming" data-region="{region}" data-date="{date_str}" data-slug="{slug}">
                         <img src="images/events/{slug}-thumb.jpg?v=20260326" alt="{name}" class="event-thumb" loading="lazy">
@@ -454,10 +446,6 @@ def generate_index_card(data, slug):
                         <div class="event-meta-row">
                             <span class="event-region">{short_pref}</span>
                         </div>
-                        <div class="event-tags">
-                            {tag_items}
-                        </div>
-                        <a href="events/{slug}.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>

--- a/scripts/generate_missing_pages_v2.py
+++ b/scripts/generate_missing_pages_v2.py
@@ -164,8 +164,8 @@ def get_html_template():
       {{
         "@type": "ListItem",
         "position": 2,
-        "name": "{cat_label}",
-        "item": "https://agave-navi.com/{cat_slug}"
+        "name": "{area_label}",
+        "item": "{area_url}"
       }},
       {{
         "@type": "ListItem",
@@ -197,7 +197,7 @@ def get_html_template():
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../{cat_slug}">{cat_label}</a> &gt;
+    <a href="{area_href}">{area_label}</a> &gt;
     <span>{name}</span>
   </nav>
 
@@ -230,8 +230,10 @@ def get_html_template():
 
 {map_section}
 
+{instagram_embed_section}
+
         <div class="detail-back">
-          <a href="../{cat_slug}" class="detail-back-link">{cat_label}に戻る</a>
+          <a href="{area_href}" class="detail-back-link">{area_label}に戻る</a>
         </div>
       </div>
 
@@ -244,10 +246,6 @@ def get_html_template():
           </div>
 {location_row}
 {admission_row}
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">{tags_text}</span>
-          </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">{region}</span>
@@ -351,20 +349,16 @@ def generate_page(ev):
     date_jp = format_date_jp(date)
     date_range_jp = format_date_range_jp(date, date_end if date_end != date else '')
 
-    # Category for breadcrumb
-    cat_slug = 'category/sokubai.html'
-    cat_label = '即売会イベント一覧'
-    if tags:
-        first_tag = tags[0]
-        if first_tag in ['マルシェ']:
-            cat_slug = 'category/marche.html'
-            cat_label = 'マルシェイベント一覧'
-        elif first_tag in ['展示会']:
-            cat_slug = 'category/exhibition.html'
-            cat_label = '展示会一覧'
-        elif first_tag in ['大型']:
-            cat_slug = 'category/large.html'
-            cat_label = '大型イベント一覧'
+    # Area-based breadcrumb (replaces former category-based breadcrumb)
+    instagram_url = ev.get('instagramUrl', '')
+    if region:
+        area_label = f'{region}のイベント'
+        area_href = f'/?region={urllib.parse.quote(region)}'
+        area_url = f'https://agave-navi.com/?region={urllib.parse.quote(region)}'
+    else:
+        area_label = 'イベント一覧'
+        area_href = '/'
+        area_url = 'https://agave-navi.com/'
 
     # Meta description (truncated)
     meta_description = description[:120] if description else f'{name}のイベント情報'
@@ -425,7 +419,21 @@ def generate_page(ev):
     else:
         map_section = ''
 
-    # Instagram section (conditional - only if sourceUrl is Instagram)
+    # Instagram embed section (Instagram post / reel iframe).
+    # Triggers when instagramUrl is set to a /p/ or /reel/ URL.
+    instagram_embed_section = ''
+    ig_post_re = re.compile(r'^https?://(?:www\.)?instagram\.com/(?:p|reel)/[^/?#]+/?')
+    if instagram_url and ig_post_re.match(instagram_url):
+        embed_url = instagram_url.rstrip('/') + '/embed/'
+        instagram_embed_section = f'''        <div class="detail-section detail-instagram-embed">
+          <h2 class="detail-section-title">Instagram投稿</h2>
+          <div class="instagram-embed-wrap">
+            <iframe src="{escape_html(embed_url)}" loading="lazy" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>
+          </div>
+          <p class="instagram-embed-link"><a href="{escape_html(instagram_url)}" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
+        </div>'''
+
+    # Instagram sidebar account link (conditional - only if sourceUrl is Instagram profile)
     if source_url and 'instagram.com' in source_url:
         ig_handle = ''
         ig_match = re.search(r'instagram\.com/([^/?]+)', source_url)
@@ -479,8 +487,9 @@ def generate_page(ev):
         date_jp=date_jp,
         date_range_jp=date_range_jp,
         time_line=time_line,
-        cat_slug=cat_slug,
-        cat_label=cat_label,
+        area_label=escape_html(area_label),
+        area_href=escape_html(area_href),
+        area_url=escape_html(area_url),
         organizer_or_name=escape_html(organizer or name),
         offers_block=offers_block,
         map_section=map_section,
@@ -489,6 +498,7 @@ def generate_page(ev):
         source_url_row=source_url_row,
         gcal_row=gcal_row,
         instagram_section=instagram_section,
+        instagram_embed_section=instagram_embed_section,
         correction_notice=correction_notice,
     )
     return html

--- a/scripts/migrate_event_pages.py
+++ b/scripts/migrate_event_pages.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+One-shot migration over events/*.html:
+
+1. Category-based breadcrumb -> area (region) breadcrumb (visible HTML + JSON-LD).
+2. Drop the "カテゴリ" info-row from the sidebar.
+3. Drop the "{cat}に戻る" detail-back link, replace with area-based back link.
+4. Inject an Instagram <iframe> embed when events.json provides an instagramUrl
+   matching /p/ or /reel/ for that slug.
+
+Idempotent: rerunning is safe.
+"""
+import json
+import re
+import urllib.parse
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+EVENTS_JSON = ROOT / 'events.json'
+EVENTS_DIR = ROOT / 'events'
+
+REGION_BY_PREF = {
+    '北海道': '北海道',
+    '青森': '東北', '岩手': '東北', '宮城': '東北', '秋田': '東北', '山形': '東北', '福島': '東北',
+    '茨城': '関東', '栃木': '関東', '群馬': '関東', '埼玉': '関東', '千葉': '関東', '東京': '関東', '神奈川': '関東',
+    '新潟': '中部', '富山': '中部', '石川': '中部', '福井': '中部',
+    '山梨': '中部', '長野': '中部', '岐阜': '中部', '静岡': '中部', '愛知': '中部',
+    '三重': '関西', '滋賀': '関西', '京都': '関西', '大阪': '関西', '兵庫': '関西', '奈良': '関西', '和歌山': '関西',
+    '鳥取': '中国', '島根': '中国', '岡山': '中国', '広島': '中国', '山口': '中国',
+    '徳島': '四国', '香川': '四国', '愛媛': '四国', '高知': '四国',
+    '福岡': '九州', '佐賀': '九州', '長崎': '九州', '熊本': '九州', '大分': '九州', '宮崎': '九州', '鹿児島': '九州', '沖縄': '九州',
+}
+
+IG_POST_RE = re.compile(r'^https?://(?:www\.)?instagram\.com/(?:p|reel)/[^/?#]+/?', re.IGNORECASE)
+
+
+def html_escape(s: str) -> str:
+    return (s or '').replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
+
+
+def load_events():
+    with open(EVENTS_JSON, 'r', encoding='utf-8') as f:
+        events = json.load(f)
+    by_slug = {e['slug']: e for e in events if 'slug' in e}
+    return by_slug
+
+
+def get_region(event):
+    if event.get('region'):
+        return event['region']
+    pref = (event.get('prefecture') or '').strip()
+    for k, v in REGION_BY_PREF.items():
+        if k in pref:
+            return v
+    return ''
+
+
+def area_link(region):
+    if region:
+        return (
+            f'{region}のイベント',
+            f'/?region={urllib.parse.quote(region)}',
+            f'https://agave-navi.com/?region={urllib.parse.quote(region)}',
+        )
+    return ('イベント一覧', '/', 'https://agave-navi.com/')
+
+
+def fallback_region_from_html(html: str) -> str:
+    m = re.search(r'<span class="info-label">開催地域</span>\s*<span class="info-value">([^<]+)</span>', html)
+    if m:
+        return m.group(1).strip()
+    return ''
+
+
+def replace_visible_breadcrumb(html: str, area_label: str, area_href: str) -> str:
+    """Replace the category breadcrumb anchor with an area anchor."""
+    pattern = re.compile(
+        r'(<nav class="breadcrumb"[^>]*>\s*<a[^>]*>ホーム</a>\s*&gt;\s*)<a href="\.\./category/[^"]+"[^>]*>[^<]+</a>'
+    )
+    new_html, n = pattern.subn(
+        lambda m: m.group(1) + f'<a href="{html_escape(area_href)}">{html_escape(area_label)}</a>',
+        html,
+        count=1,
+    )
+    if n:
+        return new_html
+
+    # Older-style single-line breadcrumb (from generate_event_page.py)
+    pattern2 = re.compile(
+        r'(<div class="breadcrumb">\s*<a href="/">ホーム</a>\s*&gt;\s*)<a href="\.\./category/[^"]+\.html">[^<]+</a>'
+    )
+    new_html, n = pattern2.subn(
+        lambda m: m.group(1) + f'<a href="{html_escape(area_href)}">{html_escape(area_label)}</a>',
+        html,
+        count=1,
+    )
+    return new_html
+
+
+def replace_jsonld_breadcrumb(html: str, area_label: str, area_url: str) -> str:
+    """Update position-2 of the BreadcrumbList structured data."""
+    pattern = re.compile(
+        r'("@type":\s*"ListItem",\s*"position":\s*2,\s*"name":\s*")[^"]+(",\s*"item":\s*")https://agave-navi\.com/category/[^"]+(")',
+        re.DOTALL,
+    )
+    return pattern.sub(rf'\g<1>{area_label}\g<2>{area_url}\g<3>', html, count=1)
+
+
+def replace_detail_back(html: str, area_label: str, area_href: str) -> str:
+    pattern = re.compile(
+        r'<a href="\.\./category/[^"]+" class="detail-back-link">[^<]+</a>'
+    )
+    return pattern.sub(
+        f'<a href="{html_escape(area_href)}" class="detail-back-link">{html_escape(area_label)}に戻る</a>',
+        html,
+        count=1,
+    )
+
+
+CATEGORY_INFO_ROW_RE = re.compile(
+    r'\n\s*<div class="info-row">\s*<span class="info-label">カテゴリ</span>\s*<span class="info-value">[^<]*</span>\s*</div>'
+)
+
+
+def remove_category_info_row(html: str) -> str:
+    return CATEGORY_INFO_ROW_RE.sub('', html)
+
+
+def inject_instagram_embed(html: str, instagram_url: str) -> str:
+    """Insert an Instagram embed iframe block before the detail-back div, if missing."""
+    if not instagram_url or not IG_POST_RE.match(instagram_url):
+        return html
+    if 'detail-instagram-embed' in html:  # already injected
+        return html
+    embed_url = instagram_url.rstrip('/') + '/embed/'
+    block = (
+        f'\n        <div class="detail-section detail-instagram-embed">\n'
+        f'          <h2 class="detail-section-title">Instagram投稿</h2>\n'
+        f'          <div class="instagram-embed-wrap">\n'
+        f'            <iframe src="{html_escape(embed_url)}" loading="lazy" frameborder="0" '
+        f'scrolling="no" allowtransparency="true" allowfullscreen></iframe>\n'
+        f'          </div>\n'
+        f'          <p class="instagram-embed-link"><a href="{html_escape(instagram_url)}" '
+        f'target="_blank" rel="noopener">Instagramで見る ↗</a></p>\n'
+        f'        </div>\n'
+    )
+    # Prefer to insert before the detail-back container so it sits at the bottom of main content.
+    needle = '<div class="detail-back">'
+    idx = html.find(needle)
+    if idx >= 0:
+        # back up to start of preceding line of whitespace
+        line_start = html.rfind('\n', 0, idx)
+        if line_start < 0:
+            line_start = idx
+        return html[:line_start] + block + html[line_start:]
+    # Fallback: append before closing of detail-main
+    return html.replace('</div>\n      </div>\n\n      <div class="detail-sidebar">', block + '      </div>\n\n      <div class="detail-sidebar">', 1)
+
+
+def migrate_file(path: Path, by_slug: dict) -> bool:
+    slug = path.stem
+    original = path.read_text(encoding='utf-8')
+    html = original
+
+    event = by_slug.get(slug, {})
+    region = get_region(event) or fallback_region_from_html(html)
+    area_label, area_href, area_url = area_link(region)
+
+    html = replace_visible_breadcrumb(html, area_label, area_href)
+    html = replace_jsonld_breadcrumb(html, area_label, area_url)
+    html = replace_detail_back(html, area_label, area_href)
+    html = remove_category_info_row(html)
+
+    instagram_url = event.get('instagramUrl', '')
+    html = inject_instagram_embed(html, instagram_url)
+
+    if html != original:
+        path.write_text(html, encoding='utf-8')
+        return True
+    return False
+
+
+def main():
+    by_slug = load_events()
+    pages = sorted(EVENTS_DIR.glob('*.html'))
+    changed = 0
+    for p in pages:
+        if migrate_file(p, by_slug):
+            changed += 1
+    print(f'Migrated {changed} / {len(pages)} event pages')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/rebuild_index.py
+++ b/scripts/rebuild_index.py
@@ -72,10 +72,6 @@ def generate_event_card(event):
 
     data_str = ' '.join([d for d in data_attrs if d])
 
-    # Generate tags HTML
-    tags_list = event.get('tags', [])
-    tags_html = generate_tags_html(tags_list)
-
     # Generate thumbnail HTML - check for imageUrl
     image_url = event.get('imageUrl', '')
     if image_url:
@@ -83,7 +79,7 @@ def generate_event_card(event):
     else:
         thumb_html = '<div class="event-thumb event-no-image"></div>'
 
-    # Build the card
+    # Build the card (entire card is clickable via data-slug; no inner detail link)
     card_html = f'''<div class="event-card" {data_str}>
                         {thumb_html}
                         <button class="fav-btn" onclick="toggleFav(event, '{slug}')" aria-label="行きたい">
@@ -100,9 +96,6 @@ def generate_event_card(event):
                         <div class="event-meta-row">
                             <span class="event-region">{get_region_display(event)}</span>
                         </div>
-                        <div class="event-tags">{tags_html}
-                        </div>
-                        <a href="events/{slug}.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>
@@ -137,7 +130,6 @@ def generate_past_event_card(event):
                         <div class="event-meta-row">
                             <span class="event-region">{get_region_display(event)}</span>
                         </div>
-                        <a href="events/{slug}.html" class="event-link">詳細を見る</a>
                         </div>
                                             <div class="card-fav-bar" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg><span>行きたい</span></div>
 </div>

--- a/style.css
+++ b/style.css
@@ -2790,3 +2790,40 @@ main {
 .map-open-link {
   display: none !important;
 }
+
+/* Instagram投稿の埋め込み（投稿/リールURLが instagramUrl にある場合） */
+.detail-instagram-embed {
+  margin-top: 1.5rem;
+}
+.detail-instagram-embed .instagram-embed-wrap {
+  position: relative;
+  max-width: 540px;
+  margin: 0 auto;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0,0,0,.08);
+  background: #fff;
+}
+.detail-instagram-embed iframe {
+  display: block;
+  width: 100%;
+  min-height: 720px;
+  border: 0;
+}
+.detail-instagram-embed .instagram-embed-link {
+  margin: .6rem 0 0;
+  text-align: center;
+  font-size: .85rem;
+}
+.detail-instagram-embed .instagram-embed-link a {
+  color: var(--gray-600, #666);
+  text-decoration: none;
+}
+.detail-instagram-embed .instagram-embed-link a:hover {
+  text-decoration: underline;
+}
+
+/* カード全体クリック化（event-link 廃止に伴うカーソル表示） */
+.events-grid .event-card[data-slug]:not(.event-ended) {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- 「詳細を見る→」リンクを全カードから削除し、カード全体を data-slug ベースでクリック可能に
- カテゴリー（即売会/マルシェ/大型/展示会）の概念をUIから全廃止：フィルタタブ・タグchip・カテゴリinfo-rowを削除
- 詳細ページのパンくずをカテゴリーベース → 地域（エリア）ベース（`/?region=○○`）に変更（JSON-LD BreadcrumbList も同期）
- `events.json` に `instagramUrl` フィールドを追加し、`url` から `/p/`・`/reel/` 投稿URL3件を自動移行。詳細ページで iframe 埋め込み描画

## Files
- `index.html`: フィルタタブ／タグchip／詳細リンク削除、カードクリックを data-slug 化（323行削減）
- `events.json`: `instagramUrl` フィールド追加（3件にバックフィル）
- `events/*.html`: 110ページに対し `scripts/migrate_event_pages.py` で一括移行（カテゴリパンくず→エリア・カテゴリ行削除・IG埋め込み挿入）
- `style.css`: Instagram 埋め込みのスタイル + `event-card[data-slug]` のカーソル指定
- `scripts/rebuild_index.py` / `generate_missing_pages_v2.py` / `generate_event_page.py`: 上記方針に合わせて生成ロジック更新

## Test plan
- [ ] トップページでカード全体がクリックできる（リンク・お気に入りボタン以外）
- [ ] フィルタタブ「即売会/マルシェ/大型イベント/展示会」が消えている
- [ ] カード上のタグchipが表示されない
- [ ] 詳細ページのパンくずが「ホーム > ○○のイベント > イベント名」になっている
- [ ] サイドバーの「カテゴリ」行が消えている
- [ ] `events/fukuoka-green-party-6th-2026.html` 等 instagramUrl 持ちページで iframe 埋め込みが描画される

🤖 Generated with [Claude Code](https://claude.com/claude-code)