### PR TITLE
テンプレートベースの詳細ページ生成システム導入

### DIFF
--- a/build-detail-pages.py
+++ b/build-detail-pages.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+build-detail-pages.py
+events.json + templates/detail.html → events/*.html
+
+Usage:
+  python3 build-detail-pages.py                 # Generate all pages
+  python3 build-detail-pages.py --slug foo-2026  # Generate one page
+  python3 build-detail-pages.py --dry-run        # Preview without writing
+"""
+
+import json
+import os
+import sys
+import argparse
+from datetime import datetime, timedelta
+from urllib.parse import quote
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+EVENTS_JSON = os.path.join(SCRIPT_DIR, 'events.json')
+TEMPLATE_FILE = os.path.join(SCRIPT_DIR, 'templates', 'detail.html')
+OUTPUT_DIR = os.path.join(SCRIPT_DIR, 'events')
+CSS_VERSION = '20260501a'
+JS_VERSION = '20260501a'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+WEEKDAYS_JA = ['月', '火', '水', '木', '金', '土', '日']
+
+def date_to_japanese(date_str):
+    """2026-05-03 → 2026年5月3日（日）"""
+    if not date_str:
+        return ''
+    try:
+        dt = datetime.strptime(date_str, '%Y-%m-%d')
+        wd = WEEKDAYS_JA[dt.weekday()]
+        return f'{dt.year}年{dt.month}月{dt.day}日（{wd}）'
+    except ValueError:
+        return date_str
+
+def make_date_display_full(ev):
+    """sidebar用のフル日時表示を生成"""
+    date_str = ev.get('date', '')
+    date_end = ev.get('dateEnd', '')
+    time_str = ev.get('time', '')
+
+    if not date_str:
+        return ev.get('dateDisplay', '未定')
+
+    start_ja = date_to_japanese(date_str)
+
+    if date_end and date_end != date_str:
+        try:
+            end_dt = datetime.strptime(date_end, '%Y-%m-%d')
+            wd = WEEKDAYS_JA[end_dt.weekday()]
+            end_display = f'{end_dt.month}月{end_dt.day}日（{wd}）'
+            display = f'{start_ja} 〜 {end_display}'
+        except ValueError:
+            display = start_ja
+    else:
+        display = start_ja
+
+    if time_str:
+        display += f' {time_str}'
+
+    return display
+
+def make_date_display_short(ev):
+    """header meta用の短い日付表示"""
+    date_str = ev.get('date', '')
+    if not date_str:
+        return ev.get('dateDisplay', '未定')
+    return date_to_japanese(date_str)
+
+def make_gcal_url(ev):
+    """Google Calendar追加URL"""
+    name = ev.get('name', '')
+    date_str = ev.get('date', '')
+    date_end = ev.get('dateEnd', date_str)
+    venue = ev.get('venue', '')
+
+    if not date_str:
+        return '#'
+
+    start = date_str.replace('-', '')
+    # Google Calendar uses exclusive end date
+    try:
+        end_dt = datetime.strptime(date_end or date_str, '%Y-%m-%d') + timedelta(days=1)
+        end = end_dt.strftime('%Y%m%d')
+    except ValueError:
+        end = start
+
+    name_enc = quote(name)
+    venue_enc = quote(venue)
+    return f'https://calendar.google.com/calendar/render?action=TEMPLATE&text={name_enc}&dates={start}%2F{end}&location={venue_enc}'
+
+def make_meta_description(ev):
+    """OG description / meta description"""
+    desc = ev.get('description', '')
+    if len(desc) > 160:
+        desc = desc[:157] + '...'
+    return desc
+
+def make_instagram_section(ev):
+    """Instagram embed section (if instagramPostId exists)"""
+    post_id = ev.get('instagramPostId', '')
+    ig_url = ev.get('instagramUrl', '')
+    if not post_id and not ig_url:
+        return ''
+
+    if not post_id and ig_url:
+        # Extract post ID from URL
+        import re
+        m = re.search(r'/p/([A-Za-z0-9_-]+)', ig_url)
+        if m:
+            post_id = m.group(1)
+        else:
+            return ''
+
+    if not ig_url:
+        ig_url = f'https://www.instagram.com/p/{post_id}/'
+
+    return f'''        <div class="detail-section detail-instagram-embed">
+          <h2 class="detail-section-title">Instagram投稿</h2>
+          <div class="instagram-embed-wrap">
+            <iframe src="https://www.instagram.com/p/{post_id}/embed/" loading="lazy" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>
+          </div>
+          <p class="instagram-embed-link"><a href="{ig_url}" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
+        </div>
+'''
+
+def make_map_section(ev):
+    """Map section (if mapQuery exists)"""
+    map_query = ev.get('mapQuery', '')
+    if not map_query:
+        return ''
+
+    map_query_enc = quote(map_query)
+    return f'''        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query={map_query_enc}" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q={map_query_enc}&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+'''
+
+def make_admission_row(ev):
+    """Admission info row"""
+    admission = ev.get('admission', '')
+    if not admission:
+        return ''
+    return f'''          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">{admission}</span>
+          </div>'''
+
+def make_time_row(ev):
+    """Time info row"""
+    time_str = ev.get('time', '')
+    if not time_str:
+        return ''
+    return f'''          <div class="info-row">
+            <span class="info-label">時間</span>
+            <span class="info-value">{time_str}</span>
+          </div>'''
+
+
+def html_escape(text):
+    """Basic HTML escaping"""
+    return (text
+            .replace('&', '&amp;')
+            .replace('<', '&lt;')
+            .replace('>', '&gt;')
+            .replace('"', '&quot;'))
+
+
+# ---------------------------------------------------------------------------
+# Main build
+# ---------------------------------------------------------------------------
+
+def build_page(template, ev):
+    """Generate one detail page from template + event data"""
+    slug = ev.get('slug', '')
+    name = ev.get('name', '')
+    date = ev.get('date', '')
+    date_end = ev.get('dateEnd', '')
+    region = ev.get('region', '')
+    prefecture = ev.get('prefecture', region)
+    venue = ev.get('venue', '')
+
+    replacements = {
+        '{{slug}}': slug,
+        '{{name}}': html_escape(name),
+        '{{date}}': date,
+        '{{dateEnd}}': date_end,
+        '{{dateEndOrDate}}': date_end or date,
+        '{{dateDisplayShort}}': make_date_display_short(ev),
+        '{{dateDisplayFull}}': make_date_display_full(ev),
+        '{{region}}': region,
+        '{{regionEncoded}}': quote(region),
+        '{{prefecture}}': prefecture,
+        '{{prefectureOrRegion}}': prefecture or region,
+        '{{venue}}': html_escape(venue) if venue else '会場未定',
+        '{{description}}': html_escape(ev.get('description', '')),
+        '{{metaDescription}}': html_escape(make_meta_description(ev)),
+        '{{gcalUrl}}': make_gcal_url(ev),
+        '{{cssVersion}}': CSS_VERSION,
+        '{{jsVersion}}': JS_VERSION,
+        '{{instagramSection}}': make_instagram_section(ev),
+        '{{mapSection}}': make_map_section(ev),
+        '{{admissionRow}}': make_admission_row(ev),
+        '{{timeRow}}': make_time_row(ev),
+    }
+
+    html = template
+    for key, value in replacements.items():
+        html = html.replace(key, value)
+
+    return html
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Build detail pages from events.json')
+    parser.add_argument('--slug', help='Generate only this slug')
+    parser.add_argument('--dry-run', action='store_true', help='Preview without writing files')
+    parser.add_argument('--events', default=EVENTS_JSON, help='Path to events.json')
+    args = parser.parse_args()
+
+    # Load template
+    with open(TEMPLATE_FILE, 'r', encoding='utf-8') as f:
+        template = f.read()
+
+    # Load events
+    with open(args.events, 'r', encoding='utf-8') as f:
+        events = json.load(f)
+
+    # Filter if slug specified
+    if args.slug:
+        events = [e for e in events if e['slug'] == args.slug]
+        if not events:
+            print(f'Error: slug "{args.slug}" not found in events.json')
+            sys.exit(1)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    generated = 0
+    skipped = 0
+    for ev in events:
+        slug = ev.get('slug', '')
+        if not slug:
+            skipped += 1
+            continue
+
+        # Skip events with no date (incomplete data)
+        if not ev.get('date'):
+            print(f'  SKIP (no date): {slug}')
+            skipped += 1
+            continue
+
+        html = build_page(template, ev)
+        output_path = os.path.join(OUTPUT_DIR, f'{slug}.html')
+
+        if args.dry_run:
+            print(f'  DRY-RUN: {slug}.html ({len(html)} bytes)')
+        else:
+            with open(output_path, 'w', encoding='utf-8') as f:
+                f.write(html)
+            print(f'  Generated: {slug}.html')
+
+        generated += 1
+
+    print(f'\nDone: {generated} generated, {skipped} skipped')
+
+
+if __name__ == '__main__':
+    main()

--- a/events.json
+++ b/events.json
@@ -1,755 +1,5 @@
 [
   {
-    "slug": "yokohama-flower-garden-fes-2026",
-    "name": "横浜フラワー&ガーデンフェスティバル 2026",
-    "date": "2026-05-02",
-    "dateEnd": "2026-05-04",
-    "dateDisplay": "2026.05.2-4",
-    "location": "パシフィコ横浜",
-    "prefecture": "神奈川",
-    "region": "関東",
-    "tags": [
-      "大型",
-      "マルシェ",
-      "展示会"
-    ],
-    "status": "upcoming",
-    "admission": "前売¥1,600",
-    "imageUrl": "https://yfg-fes.jp/assets/img/slide/main_title26.webp",
-    "description": "パシフィコ横浜で開催。GREEN×EXPO 2027プレ企画。バラの展示・ガーデンデザイン・物販。前売¥1,600。",
-    "sourceUrl": "https://yfg-fes.jp/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "sumi-no-engei-2026-05-02",
-    "name": "隅の園藝",
-    "date": "2026-05-02",
-    "dateEnd": "2026-05-02",
-    "dateDisplay": "2026.05.02",
-    "location": "東京",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "fukuoka-green-party-6th-2026",
-    "name": "第6回 福岡グリーンパーティー",
-    "date": "2026-05-03",
-    "dateEnd": "2026-05-04",
-    "dateDisplay": "2026.05.03-04",
-    "location": "志摩中央公園",
-    "prefecture": "福岡",
-    "region": "九州",
-    "description": "福岡県糸島市・志摩中央公園で開催される園芸イベント第6回。「グリパ」の愛称で知られる屋外型植物マーケット。アガベ・塊根植物・多肉植物を扱う店舗とフード出店が集結。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/p/DTH4ktKEhUq/",
-    "time": "10:00〜16:00",
-    "admission": "無料",
-    "sourceUrl": "https://www.instagram.com/fukuoka_green_party/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-29",
-    "instagramUrl": "https://www.instagram.com/p/DTH4ktKEhUq/"
-  },
-  {
-    "slug": "picnic-garden-vol20-aobayama-2026",
-    "name": "ピクニックガーデン vol.20 in 青葉山公園",
-    "date": "2026-05-03",
-    "dateEnd": "2026-05-03",
-    "dateDisplay": "2026.05.03",
-    "location": "青葉山公園",
-    "prefecture": "宮城",
-    "region": "東北",
-    "description": "宮城県仙台市・青葉山公園で開催される多肉植物マルシェ第20回。キングプランツ主催で10店舗以上の多肉植物専門店が出店し、珍しい品種の販売やワークショップを開催。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/picnic.king.plants/",
-    "sourceUrl": "https://pukubook.jp/events/picnic-garden-20",
-    "addedDate": "2026-05-01"
-  },
-  {
-    "slug": "plant-freaks-special-2026-05",
-    "name": "PLANT FREAKS Special",
-    "date": "2026-05-04",
-    "dateEnd": "2026-05-05",
-    "dateDisplay": "2026.05.04-05",
-    "location": "オリナス錦糸町",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "塊根植物やアガベを中心とした珍奇植物の即売会。東京・錦糸町で開催されるPLANT FREAKSのスペシャル版。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/plant_fks/"
-  },
-  {
-    "slug": "haru-saboten-wakayama-2026",
-    "name": "春のサボテン即売会",
-    "date": "2026-05-04",
-    "dateEnd": "2026-05-05",
-    "dateDisplay": "2026.05.04-05",
-    "location": "和歌山",
-    "prefecture": "和歌山",
-    "region": "関西",
-    "description": "和歌山で開催される春のサボテン即売会。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "jiyugaoka-botanical-market-2026",
-    "name": "Jiyugaoka Botanical Market",
-    "date": "2026-05-04",
-    "dateEnd": "2026-05-05",
-    "dateDisplay": "2026.05.04-05",
-    "location": "自由が丘",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "shoku-sai-vol9-izumo-2026",
-    "name": "植祭 vol.9",
-    "date": "2026-05-05",
-    "dateEnd": "2026-05-05",
-    "dateDisplay": "2026.05.05",
-    "location": "飯塚農園（出雲市）",
-    "prefecture": "島根",
-    "region": "中国",
-    "description": "島根県出雲市・飯塚農園で開催される植物イベント第9回。多肉植物やアガベの即売会。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "grateful-days-10th-osaka-2026",
-    "name": "Grateful Days 〜 The 10th episode 〜",
-    "date": "2026-05-05",
-    "dateEnd": "2026-05-06",
-    "dateDisplay": "2026.05.05-06",
-    "location": "大阪",
-    "prefecture": "大阪",
-    "region": "関西",
-    "description": "大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "sumi-no-engei-2026-05-09",
-    "name": "隅の園藝",
-    "date": "2026-05-09",
-    "dateEnd": "2026-05-09",
-    "dateDisplay": "2026.05.09",
-    "location": "東京",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "collect-plants-vol2",
-    "name": "Collect Plants Vol.2",
-    "date": "2026-05-09",
-    "dateEnd": "2026-05-10",
-    "dateDisplay": "2026.05.9-10",
-    "location": "グランメッセ熊本",
-    "prefecture": "熊本",
-    "region": "九州",
-    "tags": [
-      "大型",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "imageUrl": "https://collect-plants.com/cms/wp-content/uploads/2025/12/Vol.2-1.png",
-    "description": "グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。",
-    "sourceUrl": "https://collect-plants.com/event/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "botanical-marche-kanazawa-2026",
-    "name": "ボタニカルマルシェ金沢2026",
-    "date": "2026-05-09",
-    "dateDisplay": "2026.05.09",
-    "location": "金沢（会場未確定）",
-    "prefecture": "石川",
-    "region": "中部",
-    "tags": [
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "admission": "無料",
-    "description": "石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。",
-    "sourceUrl": "",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "coco-et-nico-bond-project-2026",
-    "name": "COCO ET NICO presents Bond PROJECT",
-    "date": "2026-05-09",
-    "dateEnd": "2026-05-09",
-    "dateDisplay": "2026.05.09",
-    "location": "市原湖畔美術館",
-    "prefecture": "千葉",
-    "region": "関東",
-    "description": "ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/cocoetnico_aya/"
-  },
-  {
-    "slug": "must-buy-market-okinawa-2026",
-    "name": "MUST BUY MARKET!",
-    "date": "2026-05-09",
-    "dateEnd": "2026-05-10",
-    "dateDisplay": "2026.05.09-10",
-    "location": "沖縄",
-    "prefecture": "沖縄",
-    "region": "九州",
-    "description": "沖縄で開催される植物販売マーケット。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "picnic-garden-vol21-is-new-base-2026",
-    "name": "ピクニックガーデン vol.21 in I'S NEW BASE",
-    "date": "2026-05-10",
-    "dateEnd": "2026-05-10",
-    "dateDisplay": "2026.05.10",
-    "location": "I'S NEW BASE（会津若松市）",
-    "prefecture": "福島",
-    "region": "東北",
-    "description": "福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。",
-    "tags": [
-      "マルシェ",
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "fushimi-daisakusen-vol2",
-    "name": "伏見大作戦 vol.2",
-    "date": "2026-05-16",
-    "dateDisplay": "2026.05.16",
-    "location": "三谷商事株式会社 屋外スペース",
-    "prefecture": "京都",
-    "region": "関西",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "admission": "無料",
-    "description": "京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。",
-    "sourceUrl": "",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "enjoy-place-outside-tsukuba-2026",
-    "name": "enjoy place outside",
-    "date": "2026-05-16",
-    "dateEnd": "2026-05-16",
-    "dateDisplay": "2026.05.16",
-    "location": "つくば中央公園",
-    "prefecture": "茨城",
-    "region": "関東",
-    "description": "茨城県つくば市・つくば中央公園で2026年初開催の屋外マルシェ。植物・古道具・ガーデン雑貨など約102店が集結。植物ジャンル35店で多肉植物専門店も10店以上ラインナップ。雨天決行。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/enjoy_place_outside",
-    "sourceUrl": "https://pukubook.jp/events/enjoy-place-outside-2026",
-    "addedDate": "2026-05-01"
-  },
-  {
-    "slug": "saikiengei-fukuyama-marche-2026",
-    "name": "SaikiEngei to 福山deマルシェ",
-    "date": "2026-05-17",
-    "dateEnd": "2026-05-17",
-    "dateDisplay": "2026.05.17",
-    "location": "しまなみアースランド",
-    "prefecture": "愛媛",
-    "region": "四国",
-    "description": "愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。",
-    "tags": [
-      "マルシェ",
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "tenkaichi-2026",
-    "name": "第6回 天下一植物界",
-    "date": "2026-05-23",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.23-24",
-    "location": "京セラドーム大阪",
-    "prefecture": "大阪",
-    "region": "近畿",
-    "tags": [
-      "大型",
-      "展示会",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "imageUrl": "https://no1plantae.com/images/0/9/9/5/1/099514bd64e0fd9ea8df64efc26b32ff4463f7c5-img7956.jpeg",
-    "description": "京セラドーム大阪にて。約75店舗が出店する大型植物即売会。ジャンルの垣根を超えた植物の祭典。",
-    "sourceUrl": "https://no1plantae.com/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "border-break-6th-2026",
-    "name": "BORDER BREAK!! 6th",
-    "date": "2026-05-23",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.23-24",
-    "location": "京セラドーム大阪 スカイホール",
-    "prefecture": "大阪",
-    "region": "関西",
-    "tags": [
-      "大型",
-      "即売会",
-      "展示会"
-    ],
-    "status": "upcoming",
-    "imageUrl": "https://no1plantae.com/user/pages/01.home/01._home/R0001118.JPG",
-    "description": "京セラドーム大阪スカイホールにて。世界の熱帯植物が集結するトレードフェア。展示・販売・トーク。",
-    "sourceUrl": "https://no1plantae.com/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "greensnap-marche-hiroshima-2026",
-    "name": "GreenSnap Marche HIROSHIMA 2026",
-    "date": "2026-05-23",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.23-24",
-    "location": "広島",
-    "prefecture": "広島",
-    "region": "中国",
-    "tags": [
-      "マルシェ",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "description": "GreenSnap主催の植物マルシェ広島版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。",
-    "sourceUrl": "https://greensnap.jp/event/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "haze-various-genres-marche-2026",
-    "name": "HAZE -various genres marche",
-    "date": "2026-05-23",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.23-24",
-    "location": "茨城県内会場",
-    "prefecture": "茨城",
-    "region": "関東",
-    "description": "植物を含む多ジャンルのマルシェイベント。アガベ・塊根植物・多肉植物の販売も。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "hosokawa-botafes-2026-spring",
-    "name": "HOSOKAWA BOTAFES '26 spring",
-    "date": "2026-05-23",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.23-24",
-    "location": "旧細河小学校",
-    "prefecture": "大阪",
-    "region": "関西",
-    "description": "大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "url": "https://botafes.jp/"
-  },
-  {
-    "slug": "isij-big-bazaar-2026-05-24",
-    "name": "5月のサボテン・多肉植物ビッグバザール",
-    "date": "2026-05-24",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.24",
-    "location": "五反田TOCビル 13階",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。",
-    "tags": [
-      "大型",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "http://isij.net/"
-  },
-  {
-    "slug": "myoko-taniku-market-13th-2026",
-    "name": "妙高多肉市場 13th",
-    "date": "2026-05-24",
-    "dateEnd": "2026-05-24",
-    "dateDisplay": "2026.05.24",
-    "location": "道の駅あらい フィールド妙高",
-    "prefecture": "新潟",
-    "region": "北陸",
-    "description": "新潟県妙高市・道の駅あらいで毎月開催される多肉植物の即売会第13回。県内外の栽培家や園芸愛好家による多肉植物・雑貨販売とキッチンカーが集結。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/_myoko_plants_market_/"
-  },
-  {
-    "slug": "gotanda-big-bazaar-2026-05",
-    "name": "サボテン・多肉植物ビッグバザール",
-    "date": "2026-05-24",
-    "dateDisplay": "2026年5月24日（日）",
-    "location": "五反田TOCビル",
-    "prefecture": "東京",
-    "region": "関東",
-    "tags": [
-      "大型",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "admission": "500円",
-    "imageUrl": "http://isij.net/20.jpg",
-    "description": "ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。",
-    "sourceUrl": "http://isij.net/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "iku-matsuri-utsunomiya-2026",
-    "name": "樹祭 in 宇都宮 2026",
-    "date": "2026-05-30",
-    "dateEnd": "2026-05-31",
-    "dateDisplay": "2026.05.30-31",
-    "location": "宇都宮市",
-    "prefecture": "栃木",
-    "region": "関東",
-    "tags": [
-      "即売会",
-      "大型"
-    ],
-    "status": "upcoming",
-    "admission": "無料",
-    "description": "栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会です。",
-    "sourceUrl": "https://www.instagram.com/iku_matsuri/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "botanical-botanical-tokyo-2026",
-    "name": "BOTANICAL BOTANICAL TOKYO",
-    "date": "2026-05-30",
-    "dateEnd": "2026-05-31",
-    "dateDisplay": "2026.05.30-31",
-    "location": "東京都内",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "東京で開催されるボタニカルイベント。多様な植物愛好家やショップが集まる即売会。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "rhythms-of-life-2026",
-    "name": "Rhythms of Life",
-    "date": "2026-05-30",
-    "dateEnd": "2026-05-31",
-    "dateDisplay": "2026.05.30-31",
-    "location": "愛知県内",
-    "prefecture": "愛知",
-    "region": "東海",
-    "description": "愛知県で開催される植物イベント。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "plants-garage-market-2026-tsukumi",
-    "name": "Plants garage market 2026",
-    "date": "2026-05-30",
-    "dateEnd": "2026-05-31",
-    "dateDisplay": "2026.05.30-31",
-    "location": "イリノベ倉庫（津久見市）",
-    "prefecture": "大分",
-    "region": "九州",
-    "description": "大分県津久見市・イリノベ倉庫で開催される植物即売会。塊根植物・アガベ・ビカクシダなど珍しい植物や植物関連雑貨を扱う店舗が集結。Oita Plants Farmとvandaka plantsの共同開催。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "https://www.instagram.com/reel/DTEIXiekx1D/",
-    "instagramUrl": "https://www.instagram.com/reel/DTEIXiekx1D/"
-  },
-  {
-    "slug": "plants-garage-market-2026-spring",
-    "name": "Plants garage market 2026 -SPRING & SUMMER-",
-    "date": "2026-05-30",
-    "dateEnd": "2026-05-31",
-    "dateDisplay": "2026.05.30-31",
-    "time": "30日 10:00〜17:00 / 31日 10:00〜15:00",
-    "location": "イリノベ倉庫",
-    "prefecture": "大分",
-    "region": "九州",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "description": "大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。",
-    "sourceUrl": "https://www.instagram.com/plants.garage.market/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-29"
-  },
-  {
-    "slug": "green-breeze-fes-vol3",
-    "name": "GREEN BREEZE FES vol.3",
-    "date": "2026-05-31",
-    "dateDisplay": "2026.05.31",
-    "location": "本町公園",
-    "prefecture": "和歌山",
-    "region": "関西",
-    "tags": [
-      "マルシェ",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "admission": "無料",
-    "description": "和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめます。",
-    "sourceUrl": "https://www.instagram.com/green_breeze_fes/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "iwate-hana-midori-matsuri-2026",
-    "name": "花と緑のまつり",
-    "date": "2026-06-05",
-    "dateEnd": "2026-06-07",
-    "dateDisplay": "2026.06.05-07",
-    "location": "岩手",
-    "prefecture": "岩手",
-    "region": "東北",
-    "description": "岩手で開催される花と緑の祭り。植物販売会。",
-    "tags": [
-      "即売会",
-      "マルシェ"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "greensnap-marche-toyosu-2026",
-    "name": "GreenSnap Marche 豊洲 2026",
-    "date": "2026-06-06",
-    "dateEnd": "2026-06-07",
-    "dateDisplay": "2026.06.06-07",
-    "location": "豊洲公園",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。",
-    "tags": [
-      "マルシェ",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "https://greensnap.jp/event/events/greensnap-marche-toyosu-2026/",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "botanic-bomb-10th-kyoto-2026",
-    "name": "BOTANIC BOMB 10TH（ボタニックボム）",
-    "date": "2026-06-07",
-    "dateEnd": "2026-06-07",
-    "dateDisplay": "2026.06.07",
-    "location": "三段池公園",
-    "prefecture": "京都",
-    "region": "関西",
-    "description": "京都府福知山市・三段池公園で開催される植物イベント第10回。アガベ・多肉・珍奇植物が集まる即売会。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "himeji-kisotengai-shokubutsuichi-2026",
-    "name": "姫路城 奇草天外な植物市",
-    "date": "2026-06-07",
-    "dateEnd": "2026-06-07",
-    "dateDisplay": "2026.06.07",
-    "location": "姫路城",
-    "prefecture": "兵庫",
-    "region": "関西",
-    "description": "姫路城で開催される珍奇植物の即売会。アガベ・塊根植物等を販売。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming"
-  },
-  {
-    "slug": "mini-soransai-june-2026",
-    "name": "ミニ草乱祭（6月）",
-    "date": "2026-06-20",
-    "dateEnd": "2026-06-21",
-    "dateDisplay": "2026.06.20-21",
-    "location": "シマムラ園芸 第2ハウス",
-    "prefecture": "埼玉",
-    "region": "関東",
-    "description": "埼玉県越谷市のシマムラ園芸で開催されるアガベ・多肉植物の即売会。入場無料。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "https://soransai.com/"
-  },
-  {
-    "slug": "aichin-shokusai-2026",
-    "name": "愛珍植祭2026",
-    "date": "2026-06-21",
-    "dateEnd": "2026-06-21",
-    "dateDisplay": "2026.06.21",
-    "location": "刈谷市産業振興センター あいおいホール",
-    "prefecture": "愛知",
-    "region": "東海",
-    "description": "珍奇植物・アガベ・塊根植物などビザールプランツが集結する刈谷の植物即売会。入場無料・刈谷駅から徒歩圏内。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "https://www.facebook.com/p/%E6%84%9B%E7%8F%8D%E6%A4%8D%E7%A5%AD-61550067686678/"
-  },
-  {
-    "slug": "sendai-agave-shop-vol2",
-    "name": "仙台竜舌露店 Vol.2",
-    "date": "2026-06-27",
-    "dateDisplay": "2026.06.27",
-    "location": "虹色路店前 ガレージスペース",
-    "prefecture": "宮城",
-    "region": "東北",
-    "tags": [
-      "マルシェ"
-    ],
-    "status": "upcoming",
-    "admission": "無料",
-    "description": "宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。",
-    "sourceUrl": "",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "isij-big-bazaar-2026-07-12",
-    "name": "7月のサボテン・多肉植物ビッグバザール",
-    "date": "2026-07-12",
-    "dateEnd": "2026-07-12",
-    "dateDisplay": "2026.07.12",
-    "location": "五反田TOCビル 13階",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。",
-    "tags": [
-      "大型",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "http://isij.net/"
-  },
-  {
-    "slug": "isij-big-bazaar-2026-09-27",
-    "name": "9月のサボテン・多肉植物ビッグバザール",
-    "date": "2026-09-27",
-    "dateEnd": "2026-09-27",
-    "dateDisplay": "2026.09.27",
-    "location": "五反田TOCビル 13階",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。",
-    "tags": [
-      "大型",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "http://isij.net/"
-  },
-  {
-    "slug": "happy-smile-odawara-2026",
-    "name": "HAPPY SMILE",
-    "date": "2026-09-28",
-    "dateEnd": "2026-09-28",
-    "dateDisplay": "2026.09.28",
-    "time": "10:00〜16:00",
-    "location": "小田原アリーナ",
-    "prefecture": "神奈川",
-    "region": "関東",
-    "tags": [
-      "即売会"
-    ],
-    "status": "upcoming",
-    "admission": "未定",
-    "description": "神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。",
-    "sourceUrl": "https://www.instagram.com/happy_smile_plants/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "isij-big-bazaar-2026-11-22",
-    "name": "11月のサボテン・多肉植物ビッグバザール",
-    "date": "2026-11-22",
-    "dateEnd": "2026-11-22",
-    "dateDisplay": "2026.11.22",
-    "location": "五反田TOCビル 13階",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。",
-    "tags": [
-      "大型",
-      "即売会"
-    ],
-    "status": "upcoming",
-    "url": "http://isij.net/"
-  },
-  {
     "slug": "taniku-midori-marche-nabana-2026",
     "name": "多肉とみどりのマルシェ in なばなの里",
     "date": "2018-05-19",
@@ -768,7 +18,10 @@
     "description": "第12回開催。なばなの里B駐車場特設会場にて。多肉アレンジ体験（¥500）や苔玉づくり（¥1,000）のワークショップも。入場無料。",
     "sourceUrl": "https://www.nagashima-onsen.co.jp/nabana/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "なばなの里 B駐車場エリア",
+    "mapQuery": "なばなの里,桑名市",
+    "ogImage": "https://www.nagashima-onsen.co.jp/nabana/img/ogp.png"
   },
   {
     "slug": "kumagaya-taniku-fes-2026",
@@ -803,7 +56,9 @@
     "description": "渋谷の大型商業施設での期間限定ポップアップストア。",
     "sourceUrl": "https://www.instagram.com/miyashita_park_popup/",
     "eventStatus": "tbd",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "MIYASHITA PARK",
+    "mapQuery": "MIYASHITA PARK"
   },
   {
     "slug": "ibaraki-sky-palette-2026",
@@ -819,7 +74,8 @@
     "description": "茨城県の屋外施設で開催された植物マーケット。",
     "sourceUrl": "https://www.instagram.com/sky_palette_ibaraki/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "dateEnd": "2026-02-21"
   },
   {
     "slug": "plant-freaks-4th-2026",
@@ -837,7 +93,9 @@
     "description": "植物好きのための大型フェスティバル。",
     "sourceUrl": "https://www.instagram.com/plant_freaks_official/",
     "eventStatus": "tbd",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "東京",
+    "mapQuery": "東京"
   },
   {
     "slug": "fumakilla-kadan-fes-2026",
@@ -857,7 +115,9 @@
     "description": "大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。",
     "sourceUrl": "https://www.fumakilla.co.jp/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "ABCハウジング ウェルビーみのお",
+    "mapQuery": "ABCハウジング ウェルビーみのお,大阪"
   },
   {
     "slug": "bizarrefarm-spring-fes-2026",
@@ -879,7 +139,9 @@
     "organizerUrl": "https://www.instagram.com/bizarre_farm/",
     "sourceUrl": "https://www.instagram.com/bizarre_farm/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "道の駅いちごの里よしみ",
+    "mapQuery": "道の駅いちごの里よしみ"
   },
   {
     "slug": "botanical-botanical-osaka",
@@ -899,7 +161,9 @@
     "description": "大阪で開催されるボタニカルイベント。多様な植物愛好家やショップが出店する2日間の即売会です。",
     "sourceUrl": "https://www.instagram.com/botanical_botanical__/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "大阪",
+    "mapQuery": "大阪"
   },
   {
     "slug": "nara-botanical-garden-2026",
@@ -919,25 +183,9 @@
     "description": "奈良県田原本町で開催される植物の展示即売イベント。アガベや多肉植物を扱う出店者が集まります。",
     "sourceUrl": "https://www.instagram.com/nara.botanical_garden/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "wakayama-green-marche",
-    "name": "和歌山グリーンマルシェ",
-    "date": "2026-03-29",
-    "dateDisplay": "2026.03.29",
-    "location": "和歌山",
-    "prefecture": "和歌山",
-    "region": "関西",
-    "tags": [
-      "マルシェ",
-      "即売会"
-    ],
-    "status": "past",
-    "description": "多肉植物やサボテンを中心とした青果品が集まる地域マルシェ。新鮮な植物の即売会です。",
-    "sourceUrl": "https://www.instagram.com/wakayama_green_marche/",
-    "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "磯城郡田原本町",
+    "mapQuery": "磯城郡田原本町"
   },
   {
     "slug": "bota-magic-2026",
@@ -958,7 +206,30 @@
     "description": "和歌山・本町公園で開催されるボタニカルマジックイベント。多肉植物やグリーンを中心としたマルシェ。",
     "sourceUrl": "https://www.instagram.com/bota_magic/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "本町公園芝生エリア",
+    "mapQuery": "本町公園芝生エリア"
+  },
+  {
+    "slug": "wakayama-green-marche",
+    "name": "和歌山グリーンマルシェ",
+    "date": "2026-03-29",
+    "dateDisplay": "2026.03.29",
+    "location": "和歌山",
+    "prefecture": "和歌山",
+    "region": "関西",
+    "tags": [
+      "マルシェ",
+      "即売会"
+    ],
+    "status": "past",
+    "description": "多肉植物やサボテンを中心とした青果品が集まる地域マルシェ。新鮮な植物の即売会です。",
+    "sourceUrl": "https://www.instagram.com/wakayama_green_marche/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "和歌山",
+    "mapQuery": "和歌山",
+    "dateEnd": "2026-03-29"
   },
   {
     "slug": "joyful-festival-2026",
@@ -978,7 +249,9 @@
     "description": "ジョイフル本田千葉ニュータウン店で開催される植物の即売イベント。多肉植物や観葉植物が集まります。",
     "sourceUrl": "https://www.instagram.com/joyfulhonda_official/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "ジョイフル本田 千葉ニュータウン店",
+    "mapQuery": "ジョイフル本田 千葉ニュータウン店"
   },
   {
     "slug": "seiseihatake-2026",
@@ -996,7 +269,10 @@
     "description": "東京・日本橋で開催される植物即売会。実生から育成した珍奇植物が集まるイベント。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "Toky (日本橋久松町)",
+    "mapQuery": "Toky (日本橋久松町)",
+    "dateEnd": "2026-04-04"
   },
   {
     "slug": "shokuenseisai-5th",
@@ -1016,7 +292,9 @@
     "sourceUrl": "",
     "eventStatus": "confirmed",
     "dateEnd": "2026-04-05",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "なかやまフラワーハウス",
+    "mapQuery": "なかやまフラワーハウス"
   },
   {
     "slug": "the-botanical-show",
@@ -1035,7 +313,30 @@
     "description": "湘南平塚アウトレットで開催されるボタニカルイベント。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "THE OUTLETS SHONAN HIRATSUKA",
+    "mapQuery": "THE OUTLETS SHONAN HIRATSUKA"
+  },
+  {
+    "slug": "bromeliad-festa-spring-2026",
+    "name": "BROMELIAD FESTA SPRING 2026",
+    "date": "2026-04-05",
+    "dateEnd": "2026-04-05",
+    "dateDisplay": "2026.04.05",
+    "location": "板橋区立文化会館",
+    "prefecture": "東京",
+    "region": "関東",
+    "tags": [
+      "即売会",
+      "ブロメリア"
+    ],
+    "status": "past",
+    "description": "ブロメリア専門の即売会。",
+    "sourceUrl": "",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "板橋区立文化会館",
+    "mapQuery": "板橋区立文化会館"
   },
   {
     "slug": "plants-junkee-12th-2026",
@@ -1056,24 +357,22 @@
     "description": "大阪南港ATCで開催される大型植物即売イベント第12回。アガベ、多肉植物、ビザールプランツなど多数出店。",
     "sourceUrl": "https://www.instagram.com/plants_junkee/",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "大阪南港ATC ITM棟 4F特設会場",
+    "mapQuery": "大阪南港ATC ITM棟 4F特設会場"
   },
   {
-    "slug": "bromeliad-festa-spring-2026",
-    "name": "BROMELIAD FESTA SPRING 2026",
-    "date": "2026-04-05",
-    "dateEnd": "2026-04-05",
-    "dateDisplay": "2026.04.05",
-    "location": "板橋区立文化会館",
-    "prefecture": "東京",
-    "region": "関東",
+    "slug": "hanauchu-dream-garden-26",
+    "name": "第26回 花宇宙ドリームガーデン",
+    "description": "兵庫県川西市で開催される大型植物イベント。多肉植物やサボテンの専門店が集結。",
+    "dateDisplay": "2026年4月10日（金） 〜 4月12日（日）",
+    "region": "近畿",
+    "date": "2026-04-10",
+    "dateEnd": "2026-04-12",
     "tags": [
-      "即売会",
-      "ブロメリア"
+      "即売会"
     ],
-    "status": "past",
-    "description": "ブロメリア専門の即売会。",
-    "sourceUrl": "",
+    "status": "upcoming",
     "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
@@ -1094,7 +393,10 @@
     "sourceUrl": "",
     "eventStatus": "confirmed",
     "dateEnd": "2026-04-12",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "サンシャインシティ 展示ホールA<br>（東京都豊島区東池袋3-1）",
+    "mapQuery": "サンシャインシティ+展示ホールA",
+    "ogImage": "https://sunshinecity.jp/archives/001/202603/1f24737a056714394aad6df81c43215e883e3d262f85d7610e941dc5e1eae825.jpg"
   },
   {
     "slug": "greensnap-marche-yokohama-2026",
@@ -1116,6 +418,69 @@
     "description": "日本最大級の植物コミュニティ「GreenSnap」主催。山下公園おまつり広場にて。前回は約4万人来場。入場無料。",
     "sourceUrl": "https://greensnap.jp/event/",
     "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "山下公園 おまつり広場",
+    "mapQuery": "山下公園,横浜市中区",
+    "ogImage": "https://greensnap.jp/event/wp-content/themes/gs-events/images/ogp.jpg"
+  },
+  {
+    "slug": "iku-matsuri-ichinomiya-spring",
+    "name": "樹祭 in 一宮 2026春",
+    "description": "愛知県一宮市で開催される植物即売イベント。アガベ・塊根植物・観葉植物のショップが多数出店する大型即売会です。",
+    "dateDisplay": "2026年4月11日（土） 〜 4月12日（日）",
+    "region": "中部",
+    "date": "2026-04-11",
+    "dateEnd": "2026-04-12",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "tilly-fes-vol5-2026",
+    "name": "Tilly FES Vol.5",
+    "description": "チランジア（エアプランツ）専門イベント。SPACE BANKSIAにて全国のティランジア専門ショップが集結。",
+    "dateDisplay": "2026年4月11日（土） 〜 4月12日（日）",
+    "region": "関東",
+    "date": "2026-04-11",
+    "dateEnd": "2026-04-12",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "agave-meeting-2026-kobe",
+    "name": "AGAVE MEETING 2026 KOBE",
+    "description": "神戸で開催されるアガベ専門の即売会。全国のアガベ愛好家とショップが集結する専門的なイベントです。",
+    "dateDisplay": "2026年4月12日（日）",
+    "region": "近畿",
+    "date": "2026-04-12",
+    "dateEnd": "2026-04-12",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "jungle-plants-market",
+    "name": "JUNGLE PLANTS MARKET",
+    "description": "埼玉県久喜市で開催されるジャングルプランツのマルシェ。アロイドやジャングルプランツが揃う。",
+    "dateDisplay": "2026年4月12日（日）",
+    "region": "関東",
+    "date": "2026-04-12",
+    "dateEnd": "2026-04-12",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
   {
@@ -1135,6 +500,23 @@
     "description": "香川県丸亀市で開催される珍奇植物販売会。入場無料。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "綾歌総合文化会館アイレックス",
+    "mapQuery": "綾歌総合文化会館アイレックス"
+  },
+  {
+    "slug": "sora-to-taiyo-marche-2026",
+    "name": "空と太陽のマルシェ",
+    "description": "茨城空港で開催されるグリーンマルシェ。多肉植物やハンドメイド雑貨が集まる屋外イベント。",
+    "dateDisplay": "2026年4月12日（日）",
+    "region": "関東",
+    "date": "2026-04-12",
+    "dateEnd": "2026-04-12",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
   {
@@ -1153,7 +535,9 @@
     "description": "岐阜県で開催される植物即売会。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "岐阜県内",
+    "mapQuery": "岐阜県内"
   },
   {
     "slug": "taniku-moromoro-2026-spring",
@@ -1171,7 +555,10 @@
     "description": "兵庫県西脇市で開催される多肉植物専門の青空即売会。全国のブリーダーや販売者が集まる人気イベント。",
     "sourceUrl": "https://tanikumoromoro.denku-travel.com/",
     "eventStatus": "tbd",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "道の駅 北はりまエコミュージアム",
+    "admission": "未定",
+    "mapQuery": "道の駅 北はりまエコミュージアム"
   },
   {
     "slug": "shokubutsu-hyakkaten-2026",
@@ -1191,7 +578,9 @@
     "description": "東京で開催される大型植物展示即売会。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "東京都内",
+    "mapQuery": "東京都内"
   },
   {
     "slug": "bts-beppu-taniku-show-2026",
@@ -1210,7 +599,9 @@
     "description": "大分県別府市で開催される多肉植物の即売会。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "別府市内",
+    "mapQuery": "別府市内"
   },
   {
     "slug": "fuji-taniku-plants-marche-2026",
@@ -1225,7 +616,41 @@
     "tags": [
       "即売会"
     ],
-    "status": "past"
+    "status": "past",
+    "venue": "啓芳園",
+    "mapQuery": "啓芳園",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "plants-fes-vol3",
+    "name": "PLANTS FES vol.3",
+    "description": "愛媛県で開催される植物フェス第3弾。多肉植物やアガベを中心とした即売・マルシェイベントです。",
+    "dateDisplay": "2026年4月19日（日）",
+    "region": "四国",
+    "date": "2026-04-19",
+    "dateEnd": "2026-04-19",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "monster-plants-2026",
+    "name": "モンスタープランツ 2026",
+    "description": "希少な植物種が集まる大規模展示会。全国から愛好家が集結するイベントです。",
+    "dateDisplay": "2026年4月20日（月）",
+    "region": "関東",
+    "date": "2026-04-20",
+    "dateEnd": "2026-04-20",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
   },
   {
     "slug": "haru-cactus-succulent-kuro-toyama-2026",
@@ -1241,7 +666,11 @@
       "展示会",
       "即売会"
     ],
-    "status": "past"
+    "status": "past",
+    "venue": "富山県中央植物園",
+    "mapQuery": "富山県中央植物園",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
   },
   {
     "slug": "haru-saboten-taniku-fair-sapporo-2026",
@@ -1259,7 +688,12 @@
     ],
     "status": "past",
     "url": "https://www.instagram.com/p/DVxEjm0iWCA/",
-    "instagramUrl": "https://www.instagram.com/p/DVxEjm0iWCA/"
+    "instagramUrl": "https://www.instagram.com/p/DVxEjm0iWCA/",
+    "venue": "札幌市北区新琴似町787-1-4",
+    "mapQuery": "札幌市北区新琴似町787-1-4",
+    "instagramPostId": "DVxEjm0iWCA",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
   },
   {
     "slug": "aichi-plants-fes-vol1",
@@ -1279,6 +713,46 @@
     "sourceUrl": "",
     "eventStatus": "confirmed",
     "dateEnd": "2026-04-26",
+    "addedDate": "2026-04-01",
+    "venue": "愛知県",
+    "mapQuery": "愛知県"
+  },
+  {
+    "slug": "botanical-market-akita-2026",
+    "name": "ボタニカルマーケット",
+    "date": "2026-04-25",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.25-26",
+    "location": "道の駅うご 端縫いの郷",
+    "prefecture": "秋田",
+    "region": "東北",
+    "description": "秋田県の道の駅うごで開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "past",
+    "venue": "道の駅うご 端縫いの郷",
+    "mapQuery": "道の駅うご 端縫いの郷",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "chinki-shokubutsu-ichiba-vol8-2026",
+    "name": "珍奇植物市場 Vol.8",
+    "date": "2026-04-25",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.25-26",
+    "location": "西原さわふじマルシェ さわふじ広場",
+    "prefecture": "沖縄",
+    "region": "九州",
+    "description": "沖縄で開催される珍奇植物の即売会。アガベ・塊根植物・多肉植物など希少植物が集まる。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "past",
+    "venue": "西原さわふじマルシェ さわふじ広場",
+    "mapQuery": "西原さわふじマルシェ さわふじ広場",
+    "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
   {
@@ -1298,84 +772,9 @@
     "sourceUrl": "",
     "eventStatus": "confirmed",
     "dateEnd": "2026-04-26",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "yamaguchi-plants-market-2026",
-    "name": "YAMAGUCHI PLANTS MARKET 2026",
-    "date": "2026-04-25",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.25-26",
-    "location": "ときわ公園 ときわミュージアム（山口県宇部市）",
-    "prefecture": "山口",
-    "region": "中国",
-    "description": "山口県最大の植物イベント第4回。32店舗が集結し、珍しい植物や作家鉢が並ぶ。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "past",
-    "url": "https://www.instagram.com/yamaguchi.plants.market",
-    "addedDate": "2026-04-01"
-  },
-  {
-    "slug": "paludarium-collection-parcole-3rd-2026",
-    "name": "第3回 パルダリウムコレクション パルコレ",
-    "date": "2026-04-25",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.25-26",
-    "location": "Link! 近畿大学前",
-    "prefecture": "大阪",
-    "region": "関西",
-    "description": "大阪府東大阪市で開催されるパルダリウム・植物コレクションイベント。珍奇植物やビバリウム関連の販売も。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "past"
-  },
-  {
-    "slug": "chinki-shokubutsu-ichiba-vol8-2026",
-    "name": "珍奇植物市場 Vol.8",
-    "date": "2026-04-25",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.25-26",
-    "location": "西原さわふじマルシェ さわふじ広場",
-    "prefecture": "沖縄",
-    "region": "九州",
-    "description": "沖縄で開催される珍奇植物の即売会。アガベ・塊根植物・多肉植物など希少植物が集まる。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "past"
-  },
-  {
-    "slug": "botanical-market-akita-2026",
-    "name": "ボタニカルマーケット",
-    "date": "2026-04-25",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.25-26",
-    "location": "道の駅うご 端縫いの郷",
-    "prefecture": "秋田",
-    "region": "東北",
-    "description": "秋田県の道の駅うごで開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "past"
-  },
-  {
-    "slug": "tanushimaru-garden-shokuyo-osei-vol4-2026",
-    "name": "田主丸ガーデン植物販売会 植欲旺盛 Vol.4",
-    "date": "2026-04-25",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.25-26",
-    "location": "田主丸ガーデン駐車場",
-    "prefecture": "福岡",
-    "region": "九州",
-    "description": "福岡県久留米市・田主丸ガーデンで開催される植物販売会。アガベ・多肉植物・珍奇植物の即売イベント。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "past"
+    "addedDate": "2026-04-01",
+    "venue": "岡山県",
+    "mapQuery": "岡山県"
   },
   {
     "slug": "our-plants-2-03",
@@ -1392,6 +791,47 @@
     "admission": "無料",
     "description": "京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。",
     "sourceUrl": "",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "京都県",
+    "mapQuery": "京都県",
+    "dateEnd": "2026-04-25"
+  },
+  {
+    "slug": "paludarium-collection-parcole-3rd-2026",
+    "name": "第3回 パルダリウムコレクション パルコレ",
+    "date": "2026-04-25",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.25-26",
+    "location": "Link! 近畿大学前",
+    "prefecture": "大阪",
+    "region": "関西",
+    "description": "大阪府東大阪市で開催されるパルダリウム・植物コレクションイベント。珍奇植物やビバリウム関連の販売も。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "past",
+    "venue": "Link! 近畿大学前",
+    "mapQuery": "Link! 近畿大学前",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "tanushimaru-garden-shokuyo-osei-vol4-2026",
+    "name": "田主丸ガーデン植物販売会 植欲旺盛 Vol.4",
+    "date": "2026-04-25",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.25-26",
+    "location": "田主丸ガーデン駐車場",
+    "prefecture": "福岡",
+    "region": "九州",
+    "description": "福岡県久留米市・田主丸ガーデンで開催される植物販売会。アガベ・多肉植物・珍奇植物の即売イベント。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "past",
+    "venue": "田主丸ガーデン駐車場",
+    "mapQuery": "田主丸ガーデン駐車場",
     "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
@@ -1411,6 +851,48 @@
     "description": "岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "岐阜県",
+    "mapQuery": "岐阜県",
+    "dateEnd": "2026-04-25"
+  },
+  {
+    "slug": "yamaguchi-plants-market-2026",
+    "name": "YAMAGUCHI PLANTS MARKET 2026",
+    "date": "2026-04-25",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.25-26",
+    "location": "ときわ公園 ときわミュージアム（山口県宇部市）",
+    "prefecture": "山口",
+    "region": "中国",
+    "description": "山口県最大の植物イベント第4回。32店舗が集結し、珍しい植物や作家鉢が並ぶ。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "past",
+    "url": "https://www.instagram.com/yamaguchi.plants.market",
+    "addedDate": "2026-04-01",
+    "venue": "ときわ公園 ときわミュージアム（山口県宇部市）",
+    "mapQuery": "ときわ公園 ときわミュージアム（山口県宇部市）",
+    "eventStatus": "confirmed"
+  },
+  {
+    "slug": "chinki-shokubutsu-freemarket-machida-2026",
+    "name": "珍奇植物フリーマーケット",
+    "date": "2026-04-26",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.26",
+    "location": "町田パリオ 4階",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "東京都町田市のパリオで開催される珍奇植物のフリーマーケット。アガベや塊根植物の個人売買が楽しめる。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "past",
+    "venue": "町田パリオ 4階",
+    "mapQuery": "町田パリオ 4階",
+    "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
   {
@@ -1428,6 +910,28 @@
     "admission": "無料",
     "description": "千葉県木更津市で開催されるカクタス&サボテンのフェア。サボテン愛好家が集結。",
     "sourceUrl": "",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "千葉県",
+    "mapQuery": "千葉県",
+    "dateEnd": "2026-04-26"
+  },
+  {
+    "slug": "sippo-de-marche-fukushima-2026",
+    "name": "シッポdeマルシェ",
+    "date": "2026-04-26",
+    "dateEnd": "2026-04-26",
+    "dateDisplay": "2026.04.26",
+    "location": "四季の里 旧農村レストラン",
+    "prefecture": "福島",
+    "region": "東北",
+    "description": "福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。",
+    "tags": [
+      "マルシェ"
+    ],
+    "status": "past",
+    "venue": "四季の里 旧農村レストラン",
+    "mapQuery": "四季の里 旧農村レストラン",
     "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
@@ -1447,7 +951,10 @@
     "description": "香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。",
     "sourceUrl": "",
     "eventStatus": "confirmed",
-    "addedDate": "2026-04-01"
+    "addedDate": "2026-04-01",
+    "venue": "香川県",
+    "mapQuery": "香川県",
+    "dateEnd": "2026-04-26"
   },
   {
     "slug": "tosa-muroto-cactus-8th-2026",
@@ -1462,37 +969,11 @@
     "tags": [
       "即売会"
     ],
-    "status": "past"
-  },
-  {
-    "slug": "chinki-shokubutsu-freemarket-machida-2026",
-    "name": "珍奇植物フリーマーケット",
-    "date": "2026-04-26",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.26",
-    "location": "町田パリオ 4階",
-    "prefecture": "東京",
-    "region": "関東",
-    "description": "東京都町田市のパリオで開催される珍奇植物のフリーマーケット。アガベや塊根植物の個人売買が楽しめる。",
-    "tags": [
-      "即売会"
-    ],
-    "status": "past"
-  },
-  {
-    "slug": "sippo-de-marche-fukushima-2026",
-    "name": "シッポdeマルシェ",
-    "date": "2026-04-26",
-    "dateEnd": "2026-04-26",
-    "dateDisplay": "2026.04.26",
-    "location": "四季の里 旧農村レストラン",
-    "prefecture": "福島",
-    "region": "東北",
-    "description": "福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。",
-    "tags": [
-      "マルシェ"
-    ],
-    "status": "past"
+    "status": "past",
+    "venue": "高知県室戸市内会場",
+    "mapQuery": "高知県室戸市内会場",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
   },
   {
     "slug": "hanatomofesta-2026",
@@ -1511,6 +992,273 @@
     "imageUrl": "https://hanatomofesta.com/files/libs/7138/202602261755302855.png",
     "description": "幕張メッセで開催の日本最大級ガーデニングの祭典。園芸超人カーメン君がアンバサダー。前売¥1,600。",
     "sourceUrl": "https://hanatomofesta.com/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "幕張メッセ",
+    "ogImage": "https://hanatomofesta.com/files/libs/7138/202602261755302855.png",
+    "mapQuery": "幕張メッセ"
+  },
+  {
+    "slug": "petit-to-wonder-market-2026",
+    "name": "petit to Wonder Market",
+    "description": "埼玉・キヤッセ羽生で開催される小さな植物マーケット。多肉植物や雑貨のマルシェイベント。",
+    "dateDisplay": "2026年4月29日（水）",
+    "region": "関東",
+    "date": "2026-04-29",
+    "dateEnd": "2026-04-29",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "tanifes-vol6-asahikawa-2026",
+    "name": "くうふくあったマルシェ 多肉FESTIVAL VOL.6",
+    "description": "北海道・旭川の道の駅で開催される多肉植物フェスティバル第6回。北海道最大級の多肉植物即売イベント。",
+    "dateDisplay": "2026年4月29日（水）",
+    "region": "北海道",
+    "date": "2026-04-29",
+    "dateEnd": "2026-04-29",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "sumi-no-engei-2026-05-02",
+    "name": "隅の園藝",
+    "date": "2026-05-02",
+    "dateEnd": "2026-05-02",
+    "dateDisplay": "2026.05.02",
+    "location": "東京",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "東京",
+    "mapQuery": "東京",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "yokohama-flower-garden-fes-2026",
+    "name": "横浜フラワー&ガーデンフェスティバル 2026",
+    "date": "2026-05-02",
+    "dateEnd": "2026-05-04",
+    "dateDisplay": "2026.05.2-4",
+    "location": "パシフィコ横浜",
+    "prefecture": "神奈川",
+    "region": "関東",
+    "tags": [
+      "大型",
+      "マルシェ",
+      "展示会"
+    ],
+    "status": "upcoming",
+    "admission": "前売¥1,600",
+    "imageUrl": "https://yfg-fes.jp/assets/img/slide/main_title26.webp",
+    "description": "パシフィコ横浜で開催。GREEN×EXPO 2027プレ企画。バラの展示・ガーデンデザイン・物販。前売¥1,600。",
+    "sourceUrl": "https://yfg-fes.jp/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "パシフィコ横浜 展示ホールA・B",
+    "mapQuery": "パシフィコ横浜,横浜市西区",
+    "ogImage": "https://yfg-fes.jp/assets/img/slide/main_title26.webp"
+  },
+  {
+    "slug": "fujisan-festa",
+    "name": "FUJISAN FESTA",
+    "description": "静岡県富士市で開催される大型植物フェスタ。多肉植物やサボテンが豊富。",
+    "dateDisplay": "2026年5月3日（日）",
+    "region": "中部",
+    "date": "2026-05-03",
+    "dateEnd": "2026-05-03",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "fukuoka-green-party-2026",
+    "name": "FUKUOKA GREEN PARTY 2026",
+    "description": "糸島市の志摩中央公園にて。多肉植物・コーデックス・ガーデニング資材。キッチンカーも出店。無料駐車場500台。",
+    "dateDisplay": "2026年5月3日（日） 〜 5月4日（月）",
+    "region": "九州",
+    "date": "2026-05-03",
+    "dateEnd": "2026-05-04",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "fukuoka-green-party-6th-2026",
+    "name": "第6回 福岡グリーンパーティー",
+    "date": "2026-05-03",
+    "dateEnd": "2026-05-04",
+    "dateDisplay": "2026.05.03-04",
+    "location": "志摩中央公園",
+    "prefecture": "福岡",
+    "region": "九州",
+    "description": "福岡県糸島市・志摩中央公園で開催される園芸イベント第6回。「グリパ」の愛称で知られる屋外型植物マーケット。アガベ・塊根植物・多肉植物を扱う店舗とフード出店が集結。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/p/DTH4ktKEhUq/",
+    "time": "10:00〜16:00",
+    "admission": "無料",
+    "sourceUrl": "https://www.instagram.com/fukuoka_green_party/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-29",
+    "instagramUrl": "https://www.instagram.com/p/DTH4ktKEhUq/",
+    "venue": "志摩中央公園",
+    "mapQuery": "志摩中央公園",
+    "instagramPostId": "DTH4ktKEhUq"
+  },
+  {
+    "slug": "picnic-garden-vol20-aobayama-2026",
+    "name": "ピクニックガーデン vol.20 in 青葉山公園",
+    "date": "2026-05-03",
+    "dateEnd": "2026-05-03",
+    "dateDisplay": "2026.05.03",
+    "location": "青葉山公園",
+    "prefecture": "宮城",
+    "region": "東北",
+    "description": "宮城県仙台市・青葉山公園で開催される多肉植物マルシェ第20回。キングプランツ主催で10店舗以上の多肉植物専門店が出店し、珍しい品種の販売やワークショップを開催。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/picnic.king.plants/",
+    "sourceUrl": "https://pukubook.jp/events/picnic-garden-20",
+    "addedDate": "2026-05-01",
+    "venue": "青葉山公園",
+    "mapQuery": "青葉山公園",
+    "eventStatus": "confirmed"
+  },
+  {
+    "slug": "plants-garage-market",
+    "name": "Plants Garage Market",
+    "description": "大分県津久見市で開催。アガベ・ビカクシダ・コーデックスなど珍奇植物の即売会。12時以降入場無料。",
+    "dateDisplay": "2026年5月3日（日） 〜 5月4日（月）",
+    "region": "九州",
+    "date": "2026-05-03",
+    "dateEnd": "2026-05-04",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "haru-saboten-wakayama-2026",
+    "name": "春のサボテン即売会",
+    "date": "2026-05-04",
+    "dateEnd": "2026-05-05",
+    "dateDisplay": "2026.05.04-05",
+    "location": "和歌山",
+    "prefecture": "和歌山",
+    "region": "関西",
+    "description": "和歌山で開催される春のサボテン即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "和歌山",
+    "mapQuery": "和歌山",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "jiyugaoka-botanical-market-2026",
+    "name": "Jiyugaoka Botanical Market",
+    "date": "2026-05-04",
+    "dateEnd": "2026-05-05",
+    "dateDisplay": "2026.05.04-05",
+    "location": "自由が丘",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "venue": "自由が丘",
+    "mapQuery": "自由が丘",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "plant-freaks-special-2026-05",
+    "name": "PLANT FREAKS Special",
+    "date": "2026-05-04",
+    "dateEnd": "2026-05-05",
+    "dateDisplay": "2026.05.04-05",
+    "location": "オリナス錦糸町",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "塊根植物やアガベを中心とした珍奇植物の即売会。東京・錦糸町で開催されるPLANT FREAKSのスペシャル版。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/plant_fks/",
+    "venue": "オリナス錦糸町",
+    "mapQuery": "オリナス錦糸町",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "grateful-days-10th-osaka-2026",
+    "name": "Grateful Days 〜 The 10th episode 〜",
+    "date": "2026-05-05",
+    "dateEnd": "2026-05-06",
+    "dateDisplay": "2026.05.05-06",
+    "location": "大阪",
+    "prefecture": "大阪",
+    "region": "関西",
+    "description": "大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "大阪",
+    "mapQuery": "大阪",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "shoku-sai-vol9-izumo-2026",
+    "name": "植祭 vol.9",
+    "date": "2026-05-05",
+    "dateEnd": "2026-05-05",
+    "dateDisplay": "2026.05.05",
+    "location": "飯塚農園（出雲市）",
+    "prefecture": "島根",
+    "region": "中国",
+    "description": "島根県出雲市・飯塚農園で開催される植物イベント第9回。多肉植物やアガベの即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "飯塚農園（出雲市）",
+    "mapQuery": "飯塚農園（出雲市）",
     "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
@@ -1532,6 +1280,600 @@
     "description": "二子玉川ライズで開催される都市型ボタニカルイベント。展示・即売会・ワークショップが同時開催。",
     "sourceUrl": "https://www.rise.sc/",
     "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "二子玉川ライズ",
+    "mapQuery": "二子玉川ライズ,東京都世田谷区",
+    "admission": "500円（税込）"
+  },
+  {
+    "slug": "botanical-marche-kanazawa-2026",
+    "name": "ボタニカルマルシェ金沢2026",
+    "date": "2026-05-09",
+    "dateDisplay": "2026.05.09",
+    "location": "金沢（会場未確定）",
+    "prefecture": "石川",
+    "region": "中部",
+    "tags": [
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "admission": "無料",
+    "description": "石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。",
+    "sourceUrl": "",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "石川県",
+    "mapQuery": "石川県",
+    "dateEnd": "2026-05-09"
+  },
+  {
+    "slug": "coco-et-nico-bond-project-2026",
+    "name": "COCO ET NICO presents Bond PROJECT",
+    "date": "2026-05-09",
+    "dateEnd": "2026-05-09",
+    "dateDisplay": "2026.05.09",
+    "location": "市原湖畔美術館",
+    "prefecture": "千葉",
+    "region": "関東",
+    "description": "ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/cocoetnico_aya/",
+    "venue": "市原湖畔美術館",
+    "mapQuery": "市原湖畔美術館",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "collect-plants-vol2",
+    "name": "Collect Plants Vol.2",
+    "date": "2026-05-09",
+    "dateEnd": "2026-05-10",
+    "dateDisplay": "2026.05.9-10",
+    "location": "グランメッセ熊本",
+    "prefecture": "熊本",
+    "region": "九州",
+    "tags": [
+      "大型",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "imageUrl": "https://collect-plants.com/cms/wp-content/uploads/2025/12/Vol.2-1.png",
+    "description": "グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。",
+    "sourceUrl": "https://collect-plants.com/event/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "調整中",
+    "ogImage": "https://collect-plants.com/cms/wp-content/uploads/2025/12/Vol.2-1.png",
+    "admission": "未定",
+    "mapQuery": "調整中"
+  },
+  {
+    "slug": "must-buy-market-okinawa-2026",
+    "name": "MUST BUY MARKET!",
+    "date": "2026-05-09",
+    "dateEnd": "2026-05-10",
+    "dateDisplay": "2026.05.09-10",
+    "location": "沖縄",
+    "prefecture": "沖縄",
+    "region": "九州",
+    "description": "沖縄で開催される植物販売マーケット。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "venue": "沖縄",
+    "mapQuery": "沖縄",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "sumi-no-engei-2026-05-09",
+    "name": "隅の園藝",
+    "date": "2026-05-09",
+    "dateEnd": "2026-05-09",
+    "dateDisplay": "2026.05.09",
+    "location": "東京",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "東京",
+    "mapQuery": "東京",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "picnic-garden-vol21-is-new-base-2026",
+    "name": "ピクニックガーデン vol.21 in I'S NEW BASE",
+    "date": "2026-05-10",
+    "dateEnd": "2026-05-10",
+    "dateDisplay": "2026.05.10",
+    "location": "I'S NEW BASE（会津若松市）",
+    "prefecture": "福島",
+    "region": "東北",
+    "description": "福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。",
+    "tags": [
+      "マルシェ",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "I'S NEW BASE（会津若松市）",
+    "mapQuery": "I'S NEW BASE（会津若松市）",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "enjoy-place-outside-tsukuba-2026",
+    "name": "enjoy place outside",
+    "date": "2026-05-16",
+    "dateEnd": "2026-05-16",
+    "dateDisplay": "2026.05.16",
+    "location": "つくば中央公園",
+    "prefecture": "茨城",
+    "region": "関東",
+    "description": "茨城県つくば市・つくば中央公園で2026年初開催の屋外マルシェ。植物・古道具・ガーデン雑貨など約102店が集結。植物ジャンル35店で多肉植物専門店も10店以上ラインナップ。雨天決行。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/enjoy_place_outside",
+    "sourceUrl": "https://pukubook.jp/events/enjoy-place-outside-2026",
+    "addedDate": "2026-05-01",
+    "venue": "つくば中央公園",
+    "mapQuery": "つくば中央公園",
+    "eventStatus": "confirmed"
+  },
+  {
+    "slug": "fushimi-daisakusen-vol2",
+    "name": "伏見大作戦 vol.2",
+    "date": "2026-05-16",
+    "dateDisplay": "2026.05.16",
+    "location": "三谷商事株式会社 屋外スペース",
+    "prefecture": "京都",
+    "region": "関西",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "admission": "無料",
+    "description": "京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。",
+    "sourceUrl": "",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "京都県",
+    "mapQuery": "京都県",
+    "dateEnd": "2026-05-16"
+  },
+  {
+    "slug": "saikiengei-fukuyama-marche-2026",
+    "name": "SaikiEngei to 福山deマルシェ",
+    "date": "2026-05-17",
+    "dateEnd": "2026-05-17",
+    "dateDisplay": "2026.05.17",
+    "location": "しまなみアースランド",
+    "prefecture": "愛媛",
+    "region": "四国",
+    "description": "愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。",
+    "tags": [
+      "マルシェ",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "しまなみアースランド",
+    "mapQuery": "しまなみアースランド",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "border-break-6th-2026",
+    "name": "BORDER BREAK!! 6th",
+    "date": "2026-05-23",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.23-24",
+    "location": "京セラドーム大阪 スカイホール",
+    "prefecture": "大阪",
+    "region": "関西",
+    "tags": [
+      "大型",
+      "即売会",
+      "展示会"
+    ],
+    "status": "upcoming",
+    "imageUrl": "https://no1plantae.com/user/pages/01.home/01._home/R0001118.JPG",
+    "description": "京セラドーム大阪スカイホールにて。世界の熱帯植物が集結するトレードフェア。展示・販売・トーク。",
+    "sourceUrl": "https://no1plantae.com/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "京セラドーム大阪<br>スカイホールA・B",
+    "mapQuery": "京セラドーム大阪,大阪市西区千代崎",
+    "ogImage": "https://no1plantae.com/user/pages/01.home/01._home/R0001118.JPG",
+    "admission": "前売あり（詳細未定）"
+  },
+  {
+    "slug": "greensnap-marche-hiroshima-2026",
+    "name": "GreenSnap Marche HIROSHIMA 2026",
+    "date": "2026-05-23",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.23-24",
+    "location": "広島",
+    "prefecture": "広島",
+    "region": "中国",
+    "tags": [
+      "マルシェ",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "description": "GreenSnap主催の植物マルシェ広島版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。",
+    "sourceUrl": "https://greensnap.jp/event/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "広島市内（会場未確定）",
+    "mapQuery": "広島市",
+    "admission": "無料"
+  },
+  {
+    "slug": "haze-various-genres-marche-2026",
+    "name": "HAZE -various genres marche",
+    "date": "2026-05-23",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.23-24",
+    "location": "茨城県内会場",
+    "prefecture": "茨城",
+    "region": "関東",
+    "description": "植物を含む多ジャンルのマルシェイベント。アガベ・塊根植物・多肉植物の販売も。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "茨城県内会場",
+    "mapQuery": "茨城県内会場",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "hosokawa-botafes-2026-spring",
+    "name": "HOSOKAWA BOTAFES '26 spring",
+    "date": "2026-05-23",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.23-24",
+    "location": "旧細河小学校",
+    "prefecture": "大阪",
+    "region": "関西",
+    "description": "大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "url": "https://botafes.jp/",
+    "venue": "旧細河小学校",
+    "mapQuery": "旧細河小学校",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "tenkaichi-2026",
+    "name": "第6回 天下一植物界",
+    "date": "2026-05-23",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.23-24",
+    "location": "京セラドーム大阪",
+    "prefecture": "大阪",
+    "region": "近畿",
+    "tags": [
+      "大型",
+      "展示会",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "imageUrl": "https://no1plantae.com/images/0/9/9/5/1/099514bd64e0fd9ea8df64efc26b32ff4463f7c5-img7956.jpeg",
+    "description": "京セラドーム大阪にて。約75店舗が出店する大型植物即売会。ジャンルの垣根を超えた植物の祭典。",
+    "sourceUrl": "https://no1plantae.com/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "_htmlName": "第6回 天下一植物界 BORDER BREAK BEYOND",
+    "venue": "京セラドーム大阪 スカイホール A/B",
+    "mapQuery": "大阪府大阪市西区千代崎3丁目中2-1",
+    "ogImage": "https://no1plantae.com/images/0/9/9/5/1/099514bd64e0fd9ea8df64efc26b32ff4463f7c5-img7956.jpeg",
+    "admission": "前売りチケット制（詳細は公式サイト）"
+  },
+  {
+    "slug": "gotanda-big-bazaar-2026-05",
+    "name": "サボテン・多肉植物ビッグバザール",
+    "date": "2026-05-24",
+    "dateDisplay": "2026年5月24日（日）",
+    "location": "五反田TOCビル",
+    "prefecture": "東京",
+    "region": "関東",
+    "tags": [
+      "大型",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "admission": "500円",
+    "imageUrl": "http://isij.net/20.jpg",
+    "description": "ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。",
+    "sourceUrl": "http://isij.net/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "_htmlName": "サボテン・多肉植物ビッグバザール（5月）",
+    "venue": "五反田TOCビル 13階",
+    "mapQuery": "五反田TOCビル,東京都品川区西五反田7-22-17",
+    "ogImage": "http://isij.net/20.jpg"
+  },
+  {
+    "slug": "isij-big-bazaar-2026-05-24",
+    "name": "5月のサボテン・多肉植物ビッグバザール",
+    "date": "2026-05-24",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.24",
+    "location": "五反田TOCビル 13階",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。",
+    "tags": [
+      "大型",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "http://isij.net/",
+    "venue": "五反田TOCビル 13階",
+    "mapQuery": "五反田TOCビル 13階",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "myoko-taniku-market-13th-2026",
+    "name": "妙高多肉市場 13th",
+    "date": "2026-05-24",
+    "dateEnd": "2026-05-24",
+    "dateDisplay": "2026.05.24",
+    "location": "道の駅あらい フィールド妙高",
+    "prefecture": "新潟",
+    "region": "北陸",
+    "description": "新潟県妙高市・道の駅あらいで毎月開催される多肉植物の即売会第13回。県内外の栽培家や園芸愛好家による多肉植物・雑貨販売とキッチンカーが集結。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/_myoko_plants_market_/",
+    "venue": "道の駅あらい フィールド妙高",
+    "mapQuery": "道の駅あらい フィールド妙高",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "botanical-botanical-tokyo-2026",
+    "name": "BOTANICAL BOTANICAL TOKYO",
+    "date": "2026-05-30",
+    "dateEnd": "2026-05-31",
+    "dateDisplay": "2026.05.30-31",
+    "location": "東京都内",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "東京で開催されるボタニカルイベント。多様な植物愛好家やショップが集まる即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "addedDate": "2026-04-01",
+    "venue": "東京都内",
+    "mapQuery": "東京都内",
+    "eventStatus": "confirmed"
+  },
+  {
+    "slug": "iku-matsuri-utsunomiya-2026",
+    "name": "樹祭 in 宇都宮 2026",
+    "date": "2026-05-30",
+    "dateEnd": "2026-05-31",
+    "dateDisplay": "2026.05.30-31",
+    "location": "宇都宮市",
+    "prefecture": "栃木",
+    "region": "関東",
+    "tags": [
+      "即売会",
+      "大型"
+    ],
+    "status": "upcoming",
+    "admission": "無料",
+    "description": "栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会です。",
+    "sourceUrl": "https://www.instagram.com/iku_matsuri/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "宇都宮市",
+    "mapQuery": "宇都宮市"
+  },
+  {
+    "slug": "plants-garage-market-2026-spring",
+    "name": "Plants garage market 2026 -SPRING & SUMMER-",
+    "date": "2026-05-30",
+    "dateEnd": "2026-05-31",
+    "dateDisplay": "2026.05.30-31",
+    "time": "30日 10:00〜17:00 / 31日 10:00〜15:00",
+    "location": "イリノベ倉庫",
+    "prefecture": "大分",
+    "region": "九州",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "description": "大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。",
+    "sourceUrl": "https://www.instagram.com/plants.garage.market/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-29",
+    "_htmlName": "Plants garage market 2026 -SPRING &amp; SUMMER-",
+    "venue": "イリノベ倉庫",
+    "mapQuery": "イリノベ倉庫"
+  },
+  {
+    "slug": "plants-garage-market-2026-tsukumi",
+    "name": "Plants garage market 2026",
+    "date": "2026-05-30",
+    "dateEnd": "2026-05-31",
+    "dateDisplay": "2026.05.30-31",
+    "location": "イリノベ倉庫（津久見市）",
+    "prefecture": "大分",
+    "region": "九州",
+    "description": "大分県津久見市・イリノベ倉庫で開催される植物即売会。塊根植物・アガベ・ビカクシダなど珍しい植物や植物関連雑貨を扱う店舗が集結。Oita Plants Farmとvandaka plantsの共同開催。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "https://www.instagram.com/reel/DTEIXiekx1D/",
+    "instagramUrl": "https://www.instagram.com/reel/DTEIXiekx1D/",
+    "venue": "イリノベ倉庫（津久見市）",
+    "mapQuery": "イリノベ倉庫（津久見市）",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "rhythms-of-life-2026",
+    "name": "Rhythms of Life",
+    "date": "2026-05-30",
+    "dateEnd": "2026-05-31",
+    "dateDisplay": "2026.05.30-31",
+    "location": "愛知県内",
+    "prefecture": "愛知",
+    "region": "東海",
+    "description": "愛知県で開催される植物イベント。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "addedDate": "2026-04-01",
+    "venue": "愛知県内",
+    "mapQuery": "愛知県内",
+    "eventStatus": "confirmed"
+  },
+  {
+    "slug": "green-breeze-fes-vol3",
+    "name": "GREEN BREEZE FES vol.3",
+    "date": "2026-05-31",
+    "dateDisplay": "2026.05.31",
+    "location": "本町公園",
+    "prefecture": "和歌山",
+    "region": "関西",
+    "tags": [
+      "マルシェ",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "admission": "無料",
+    "description": "和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめます。",
+    "sourceUrl": "https://www.instagram.com/green_breeze_fes/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "本町公園",
+    "mapQuery": "和歌山市北桶屋町本町公園",
+    "dateEnd": "2026-05-31"
+  },
+  {
+    "slug": "iwate-hana-midori-matsuri-2026",
+    "name": "花と緑のまつり",
+    "date": "2026-06-05",
+    "dateEnd": "2026-06-07",
+    "dateDisplay": "2026.06.05-07",
+    "location": "岩手",
+    "prefecture": "岩手",
+    "region": "東北",
+    "description": "岩手で開催される花と緑の祭り。植物販売会。",
+    "tags": [
+      "即売会",
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "venue": "岩手",
+    "mapQuery": "岩手",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "greensnap-marche-toyosu-2026",
+    "name": "GreenSnap Marche 豊洲 2026",
+    "date": "2026-06-06",
+    "dateEnd": "2026-06-07",
+    "dateDisplay": "2026.06.06-07",
+    "location": "豊洲公園",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。",
+    "tags": [
+      "マルシェ",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "https://greensnap.jp/event/events/greensnap-marche-toyosu-2026/",
+    "addedDate": "2026-04-01",
+    "venue": "豊洲公園",
+    "mapQuery": "豊洲公園",
+    "eventStatus": "confirmed"
+  },
+  {
+    "slug": "botanic-bomb-10th-kyoto-2026",
+    "name": "BOTANIC BOMB 10TH（ボタニックボム）",
+    "date": "2026-06-07",
+    "dateEnd": "2026-06-07",
+    "dateDisplay": "2026.06.07",
+    "location": "三段池公園",
+    "prefecture": "京都",
+    "region": "関西",
+    "description": "京都府福知山市・三段池公園で開催される植物イベント第10回。アガベ・多肉・珍奇植物が集まる即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "三段池公園",
+    "mapQuery": "三段池公園",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "himeji-kisotengai-shokubutsuichi-2026",
+    "name": "姫路城 奇草天外な植物市",
+    "date": "2026-06-07",
+    "dateEnd": "2026-06-07",
+    "dateDisplay": "2026.06.07",
+    "location": "姫路城",
+    "prefecture": "兵庫",
+    "region": "関西",
+    "description": "姫路城で開催される珍奇植物の即売会。アガベ・塊根植物等を販売。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "venue": "姫路城",
+    "mapQuery": "姫路城",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "mini-soransai-june-2026",
+    "name": "ミニ草乱祭（6月）",
+    "date": "2026-06-20",
+    "dateEnd": "2026-06-21",
+    "dateDisplay": "2026.06.20-21",
+    "location": "シマムラ園芸 第2ハウス",
+    "prefecture": "埼玉",
+    "region": "関東",
+    "description": "埼玉県越谷市のシマムラ園芸で開催されるアガベ・多肉植物の即売会。入場無料。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "https://soransai.com/",
+    "venue": "シマムラ園芸 第2ハウス",
+    "mapQuery": "シマムラ園芸 第2ハウス",
+    "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   },
   {
@@ -1552,6 +1894,256 @@
     "imageUrl": "https://soransai.com/wp-content/uploads/2026/01/IMG_8558.jpg",
     "description": "シマムラ園芸第2ハウスにて。日替わりで各日20店舗が出店。多肉・コーデックス・珍奇植物が揃う。入場無料。",
     "sourceUrl": "https://soransai.com/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "シマムラ園芸 第2ハウス",
+    "mapQuery": "シマムラ園芸,埼玉県越谷市南荻島1401",
+    "ogImage": "https://soransai.com/wp-content/uploads/2026/01/IMG_8558.jpg"
+  },
+  {
+    "slug": "aichin-shokusai-2026",
+    "name": "愛珍植祭2026",
+    "date": "2026-06-21",
+    "dateEnd": "2026-06-21",
+    "dateDisplay": "2026.06.21",
+    "location": "刈谷市産業振興センター あいおいホール",
+    "prefecture": "愛知",
+    "region": "東海",
+    "description": "珍奇植物・アガベ・塊根植物などビザールプランツが集結する刈谷の植物即売会。入場無料・刈谷駅から徒歩圏内。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "https://www.facebook.com/p/%E6%84%9B%E7%8F%8D%E6%A4%8D%E7%A5%AD-61550067686678/",
+    "venue": "刈谷市産業振興センター あいおいホール",
+    "mapQuery": "刈谷市産業振興センター あいおいホール",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "sendai-agave-shop-vol2",
+    "name": "仙台竜舌露店 Vol.2",
+    "date": "2026-06-27",
+    "dateDisplay": "2026.06.27",
+    "location": "虹色路店前 ガレージスペース",
+    "prefecture": "宮城",
+    "region": "東北",
+    "tags": [
+      "マルシェ"
+    ],
+    "status": "upcoming",
+    "admission": "無料",
+    "description": "宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。",
+    "sourceUrl": "",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "宮城県",
+    "mapQuery": "宮城県",
+    "dateEnd": "2026-06-27"
+  },
+  {
+    "slug": "isij-big-bazaar-2026-07-12",
+    "name": "7月のサボテン・多肉植物ビッグバザール",
+    "date": "2026-07-12",
+    "dateEnd": "2026-07-12",
+    "dateDisplay": "2026.07.12",
+    "location": "五反田TOCビル 13階",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。",
+    "tags": [
+      "大型",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "http://isij.net/",
+    "venue": "五反田TOCビル 13階",
+    "mapQuery": "五反田TOCビル 13階",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "isij-big-bazaar-2026-09-27",
+    "name": "9月のサボテン・多肉植物ビッグバザール",
+    "date": "2026-09-27",
+    "dateEnd": "2026-09-27",
+    "dateDisplay": "2026.09.27",
+    "location": "五反田TOCビル 13階",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。",
+    "tags": [
+      "大型",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "http://isij.net/",
+    "venue": "五反田TOCビル 13階",
+    "mapQuery": "五反田TOCビル 13階",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "happy-smile-odawara-2026",
+    "name": "HAPPY SMILE",
+    "date": "2026-09-28",
+    "dateEnd": "2026-09-28",
+    "dateDisplay": "2026.09.28",
+    "time": "10:00〜16:00",
+    "location": "小田原アリーナ",
+    "prefecture": "神奈川",
+    "region": "関東",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "admission": "未定",
+    "description": "神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。",
+    "sourceUrl": "https://www.instagram.com/happy_smile_plants/",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01",
+    "venue": "小田原アリーナ",
+    "mapQuery": "小田原アリーナ,神奈川"
+  },
+  {
+    "slug": "isij-big-bazaar-2026-11-22",
+    "name": "11月のサボテン・多肉植物ビッグバザール",
+    "date": "2026-11-22",
+    "dateEnd": "2026-11-22",
+    "dateDisplay": "2026.11.22",
+    "location": "五反田TOCビル 13階",
+    "prefecture": "東京",
+    "region": "関東",
+    "description": "ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。",
+    "tags": [
+      "大型",
+      "即売会"
+    ],
+    "status": "upcoming",
+    "url": "http://isij.net/",
+    "venue": "五反田TOCビル 13階",
+    "mapQuery": "五反田TOCビル 13階",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "botanical-circus-7-2026",
+    "name": "Botanical Circus 7",
+    "description": "東京・京橋で開催されるビザールプランツ・珍奇植物の展示即売イベント第7回。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "engei-yaroze-vol11-2026",
+    "name": "園藝野郎勢 Vol.11 2026 春の陣",
+    "description": "岡山県赤磐市の熊山英国庭園で開催される植物即売イベント。珍奇植物やアガベ愛好家が集まる。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "fujiyama-days-little-green-park-2026",
+    "name": "FUJIYAMA DAYS LITTLE GREEN PARK",
+    "description": "静岡県富士市の富士中央公園で開催されるグリーン系マルシェ。植物販売やワークショップを楽しめる。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "fukutomo-marche-3-2026",
+    "name": "第3回 福友マルシェ",
+    "description": "多肉植物・アガベ・ティランジアなどの植物と雑貨の即売会。出店者による交換会や特別苗の抽選販売も実施。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "green-day-vol15-2026",
+    "name": "Green Day vol.15",
+    "description": "静岡市清水区の日本平運動公園で開催されるグリーン系イベント。多肉植物やアガベなどの即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "haru-saboten-taniku-fair-2026",
+    "name": "春のサボテン多肉植物フェア",
+    "description": "札幌カクタスクラブ協力による、サボテン・多肉植物の展示販売会。百合が原公園内で開催。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "jr-takashimaya-raflum-2026",
+    "name": "JR名古屋タカシマヤ × RAFLUM ポップアップ",
+    "description": "東京の塊根植物・多肉植物専門店RAFLUMのポップアップショップ。レアな塊根植物や鉢の販売。予約不要。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "mebuki-sai-2026",
+    "name": "芽吹祭",
+    "description": "東京・新宿で開催される春の植物イベント。アガベや多肉植物を含む多彩な植物が集まる展示即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "plants-2306-3rd-anniversary-2026",
+    "name": "PLANTS 2306 3rd ANNIVERSARY FESTIVAL",
+    "description": "三重県で開催されるPLANTS 2306の3周年記念フェスティバル。植物の展示即売会。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "plants-fes-vol3-ehime-2026",
+    "name": "PLANTS FES Vol.3",
+    "description": "愛媛県で開催される多肉植物・アガベの即売イベント第3回。spikybase/MELLOW PLANTS COFFEE主催。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
+    "eventStatus": "confirmed",
+    "addedDate": "2026-04-01"
+  },
+  {
+    "slug": "raflum-popup-nagoya-takashimaya-2026",
+    "name": "RAFLUM POP-UP（ジェイアール名古屋タカシマヤ）",
+    "description": "ジェイアール名古屋タカシマヤで開催されるRAFLUMのポップアップストア。多肉植物・珍奇植物の展示販売。",
+    "tags": [
+      "即売会"
+    ],
+    "status": "upcoming",
     "eventStatus": "confirmed",
     "addedDate": "2026-04-01"
   }

--- a/events/agave-meeting-2026-kobe.html
+++ b/events/agave-meeting-2026-kobe.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "兵庫",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "兵庫",
+        "addressRegion": "近畿",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月12日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">兵庫</span>
+        <span class="detail-meta-item">近畿</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月12日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">近畿</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=AGAVE+MEETING+2026+KOBE&dates=20260412%2F20260413&location=%E5%85%B5%E5%BA%AB" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=AGAVE%20MEETING%202026%20KOBE&dates=20260412%2F20260413&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'agave-meeting-2026-kobe';

--- a/events/aichi-plants-fes-vol1.html
+++ b/events/aichi-plants-fes-vol1.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/aichi-plants-fes-vol1.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AICHI植フェス Vol.1 | アガベイベントナビ</title>
-    <meta name="description" content="愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。">
-    <meta property="og:title" content="AICHI植フェス Vol.1">
-    <meta property="og:description" content="愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/aichi-plants-fes-vol1.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt; AICHI植フェス Vol.1</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>AICHI植フェス Vol.1</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-25">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月25日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">愛知県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>AICHI植フェス Vol.1は愛知県で開催される植物イベントです。愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=愛知%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年04月25日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">愛知県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=AICHI植フェス Vol.1&dates=20260425%2F20260427&location=愛知&details=AICHI植フェス Vol.1+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/aichi-plants-fes-vol1.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AICHI植フェス Vol.1 | アガベイベントナビ</title>
+  <meta name="description" content="愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。">
+  <meta name="keywords" content="AICHI植フェス Vol.1,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="AICHI植フェス Vol.1 | アガベイベントナビ">
+  <meta property="og:description" content="愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/aichi-plants-fes-vol1.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "AICHI植フェス Vol.1",
-    "description": "愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。",
     "startDate": "2026-04-25",
-    "location": {
-        "@type": "Place",
-        "name": "すいとぴあ江南",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "愛知県",
-            "addressLocality": "すいとぴあ江南"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-04-26",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "AICHI植フェス Vol.1"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "愛知県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "愛知",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/aichi-plants-fes-vol1.html"
+    "description": "愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "AICHI植フェス Vol.1"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "中部のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E9%83%A8"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "AICHI植フェス Vol.1"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt;
+    <span>AICHI植フェス Vol.1</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>AICHI植フェス Vol.1</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-25" data-date-end="2026-04-26"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月25日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">愛知</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>愛知県江南市で開催される植物フェスティバル。多種多様な植物の即売会。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E6%84%9B%E7%9F%A5%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E6%84%9B%E7%9F%A5%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月25日（土） 〜 4月26日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">愛知県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">中部</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=AICHI%E6%A4%8D%E3%83%95%E3%82%A7%E3%82%B9%20Vol.1&dates=20260425%2F20260427&location=%E6%84%9B%E7%9F%A5%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'aichi-plants-fes-vol1';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/aichin-shokusai-2026.html
+++ b/events/aichin-shokusai-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>珍奇植物・アガベ・塊根植物などビザールプランツが集結する刈谷の植物即売会。入場無料・刈谷駅から徒歩圏内。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%88%88%E8%B0%B7%E5%B8%82%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC%20%E3%81%82%E3%81%84%E3%81%8A%E3%81%84%E3%83%9B%E3%83%BC%E3%83%AB&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
@@ -156,7 +159,9 @@
             <span class="info-value">東海</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%84%9B%E7%8F%8D%E6%A4%8D%E7%A5%AD2026&dates=20260621%2F20260622&location=%E5%88%88%E8%B0%B7%E5%B8%82%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC+%E3%81%82%E3%81%84%E3%81%8A%E3%81%84%E3%83%9B%E3%83%BC%E3%83%AB" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%84%9B%E7%8F%8D%E6%A4%8D%E7%A5%AD2026&dates=20260621%2F20260622&location=%E5%88%88%E8%B0%B7%E5%B8%82%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC%20%E3%81%82%E3%81%84%E3%81%8A%E3%81%84%E3%83%9B%E3%83%BC%E3%83%AB" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'aichin-shokusai-2026';

--- a/events/bizarrefarm-spring-fes-2026.html
+++ b/events/bizarrefarm-spring-fes-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,14 +45,7 @@
     "description": "道の駅いちごの里よしみで開催される多肉植物・サボテンの即売会。キッチンカーも出店する春の恒例イベント。",
     "organizer": {
       "@type": "Organization",
-      "name": "@bizarre_farm"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
+      "name": "bizarrefarm SPRING FES 2026"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>道の駅いちごの里よしみで開催される多肉植物・サボテンの即売会。キッチンカーも出店する春の恒例イベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%84%E3%81%A1%E3%81%94%E3%81%AE%E9%87%8C%E3%82%88%E3%81%97%E3%81%BF&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -152,34 +148,31 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年3月28日（土） 〜 3月29日（日）
-            9:00〜16:00</span>
+            <span class="info-value">2026年3月28日（土） 〜 3月29日（日） 9:00〜16:00</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">道の駅いちごの里よしみ</span>
           </div>
           <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
           </div>
           <div class="info-row">
-            <span class="info-label">開催地域</span>
-            <span class="info-value">関東</span>
+            <span class="info-label">時間</span>
+            <span class="info-value">9:00〜16:00</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=bizarrefarm+SPRING+FES+2026&dates=20260328%2F20260330&location=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%84%E3%81%A1%E3%81%94%E3%81%AE%E9%87%8C%E3%82%88%E3%81%97%E3%81%BF" target="_blank" rel="noopener" class="gcal-btn">
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=bizarrefarm%20SPRING%20FES%202026&dates=20260328%2F20260330&location=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%84%E3%81%A1%E3%81%94%E3%81%AE%E9%87%8C%E3%82%88%E3%81%97%E3%81%BF" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/bizarre_farm/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@bizarre_farm</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -219,7 +212,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'bizarrefarm-spring-fes-2026';

--- a/events/border-break-6th-2026.html
+++ b/events/border-break-6th-2026.html
@@ -1,310 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/border-break-6th-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BORDER BREAK!! 6th | アガベイベントナビ</title>
-    <meta name="description" content="世界中の熱帯植物が集まるトレードフェア。ジャンルを超えた植物愛好家の交流と即売会。展示・販売・トークショー。">
-    <meta property="og:title" content="BORDER BREAK!! 6th">
-    <meta property="og:description" content="世界中の熱帯植物が集まるトレードフェア。ジャンルを超えた植物愛好家の交流と即売会。展示・販売・トークショー。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/border-break-6th-2026.html">
-    <meta property="og:image" content="https://no1plantae.com/user/pages/01.home/01._home/R0001118.JPG">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; BORDER BREAK!! 6th</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://no1plantae.com/user/pages/01.home/01._home/R0001118.JPG" onerror="this.parentElement.style.display='none'" alt="BORDER BREAK!! 6th" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>BORDER BREAK!! 6th</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-23" data-date-end="2026-05-24">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月23日（土）-24日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">大阪府</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>BORDER BREAK!! 6thは、世界中の熱帯植物が集まる大規模なトレードフェアです。京セラドーム大阪を会場に、ジャンルを超えた植物愛好家の交流と即売会が繰り広げられます。</p>
-                    <p>アガベ、ビザールプランツ、コーデックス、多肉植物など、様々な熱帯植物の展示と販売が行われます。国内外の生産者やコレクターが参加し、レアな品種との出会いが期待できます。</p>
-                    <p>展示・販売に加えて、植物の専門家によるトークショーなども開催される充実したイベント。植物愛好家にとって、ジャンルを超えた交流の場として魅力的なフェアです。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=京セラドーム大阪,大阪市西区千代崎&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年5月23日（土）-24日（日）<br>10:00〜17:00（予定）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">京セラドーム大阪<br>スカイホールA・B</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">大阪市西区千代崎</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">前売あり（詳細未定）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">開催地域</span>
-                        <span class="info-value">関西</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">内容</span>
-                        <span class="info-value">展示・販売・トークショー</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://no1plantae.com/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BORDER+BREAK%21%21+6th&dates=20260523T090000%2F20260524T170000&location=%E4%BA%AC%E3%82%BB%E3%83%A9%E3%83%89%E3%83%BC%E3%83%A0%E5%A4%A7%E9%98%AA+%E3%82%B9%E3%82%AB%E3%82%A4%E3%83%9B%E3%83%BC%E3%83%AB%2C+%E5%A4%A7%E9%98%AA%E5%BA%9C&details=BORDER+BREAK%21%21+6th+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,即売会,展示会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/border-break-6th-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BORDER BREAK!! 6th | アガベイベントナビ</title>
+  <meta name="description" content="京セラドーム大阪スカイホールにて。世界の熱帯植物が集結するトレードフェア。展示・販売・トーク。">
+  <meta name="keywords" content="BORDER BREAK!! 6th,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="BORDER BREAK!! 6th | アガベイベントナビ">
+  <meta property="og:description" content="京セラドーム大阪スカイホールにて。世界の熱帯植物が集結するトレードフェア。展示・販売・トーク。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/border-break-6th-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "BORDER BREAK!! 6th",
-    "description": "世界中の熱帯植物が集まるトレードフェア。ジャンルを超えた植物愛好家の交流と即売会。",
-    "startDate": "2026-05-23T10:00:00+09:00",
-    "endDate": "2026-05-24T17:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "京セラドーム大阪 スカイホールA・B",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "大阪府",
-            "addressLocality": "大阪市西区",
-            "streetAddress": "千代崎"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-05-23",
+    "endDate": "2026-05-24",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": false,
-    "organizer": {
-        "@type": "Organization",
-        "name": "BORDER BREAK!! 6th",
-        "url": "https://no1plantae.com/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "京セラドーム大阪&lt;br&gt;スカイホールA・B",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "大阪",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/border-break-6th-2026.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/border-break-6th-2026.html"
+    "description": "京セラドーム大阪スカイホールにて。世界の熱帯植物が集結するトレードフェア。展示・販売・トーク。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "BORDER BREAK!! 6th"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "BORDER BREAK!! 6th"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
+    <span>BORDER BREAK!! 6th</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>BORDER BREAK!! 6th</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-23" data-date-end="2026-05-24"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月23日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">大阪</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>京セラドーム大阪スカイホールにて。世界の熱帯植物が集結するトレードフェア。展示・販売・トーク。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%AC%E3%82%BB%E3%83%A9%E3%83%89%E3%83%BC%E3%83%A0%E5%A4%A7%E9%98%AA%2C%E5%A4%A7%E9%98%AA%E5%B8%82%E8%A5%BF%E5%8C%BA%E5%8D%83%E4%BB%A3%E5%B4%8E" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E4%BA%AC%E3%82%BB%E3%83%A9%E3%83%89%E3%83%BC%E3%83%A0%E5%A4%A7%E9%98%AA%2C%E5%A4%A7%E9%98%AA%E5%B8%82%E8%A5%BF%E5%8C%BA%E5%8D%83%E4%BB%A3%E5%B4%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月23日（土） 〜 5月24日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">京セラドーム大阪&lt;br&gt;スカイホールA・B</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">前売あり（詳細未定）</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BORDER%20BREAK%21%21%206th&dates=20260523%2F20260525&location=%E4%BA%AC%E3%82%BB%E3%83%A9%E3%83%89%E3%83%BC%E3%83%A0%E5%A4%A7%E9%98%AA%3Cbr%3E%E3%82%B9%E3%82%AB%E3%82%A4%E3%83%9B%E3%83%BC%E3%83%ABA%E3%83%BBB" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'border-break-6th-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/bota-magic-2026.html
+++ b/events/bota-magic-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BOTA☆MAGIC | アガベイベントナビ</title>
   <meta name="description" content="和歌山・本町公園で開催されるボタニカルマジックイベント。多肉植物やグリーンを中心としたマルシェ。">
-  <meta name="keywords" content="BOTA☆MAGIC,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="BOTA☆MAGIC,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="BOTA☆MAGIC | アガベイベントナビ">
   <meta property="og:description" content="和歌山・本町公園で開催されるボタニカルマジックイベント。多肉植物やグリーンを中心としたマルシェ。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "BOTA☆MAGIC"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>和歌山・本町公園で開催されるボタニカルマジックイベント。多肉植物やグリーンを中心としたマルシェ。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E6%9C%AC%E7%94%BA%E5%85%AC%E5%9C%92%E8%8A%9D%E7%94%9F%E3%82%A8%E3%83%AA%E3%82%A2&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -152,20 +148,23 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年3月29日（日）
-            10:00〜16:00</span>
+            <span class="info-value">2026年3月29日（日） 10:00〜16:00</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">本町公園芝生エリア</span>
           </div>
           <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
           </div>
           <div class="info-row">
-            <span class="info-label">開催地域</span>
-            <span class="info-value">関西</span>
+            <span class="info-label">時間</span>
+            <span class="info-value">10:00〜16:00</span>
           </div>
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTA%E2%98%86MAGIC&dates=20260329%2F20260330&location=%E6%9C%AC%E7%94%BA%E5%85%AC%E5%9C%92%E8%8A%9D%E7%94%9F%E3%82%A8%E3%83%AA%E3%82%A2" target="_blank" rel="noopener" class="gcal-btn">
@@ -173,13 +172,7 @@
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/bota_magic/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@bota_magic</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -219,7 +212,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'bota-magic-2026';

--- a/events/botanic-bomb-10th-kyoto-2026.html
+++ b/events/botanic-bomb-10th-kyoto-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>京都府福知山市・三段池公園で開催される植物イベント第10回。アガベ・多肉・珍奇植物が集まる即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%B8%89%E6%AE%B5%E6%B1%A0%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E4%B8%89%E6%AE%B5%E6%B1%A0%E5%85%AC%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関西</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTANIC+BOMB+10TH%EF%BC%88%E3%83%9C%E3%82%BF%E3%83%8B%E3%83%83%E3%82%AF%E3%83%9C%E3%83%A0%EF%BC%89&dates=20260607%2F20260608&location=%E4%B8%89%E6%AE%B5%E6%B1%A0%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTANIC%20BOMB%2010TH%EF%BC%88%E3%83%9C%E3%82%BF%E3%83%8B%E3%83%83%E3%82%AF%E3%83%9C%E3%83%A0%EF%BC%89&dates=20260607%2F20260608&location=%E4%B8%89%E6%AE%B5%E6%B1%A0%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'botanic-bomb-10th-kyoto-2026';

--- a/events/botanical-botanical-osaka.html
+++ b/events/botanical-botanical-osaka.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BOTANICAL BOTANICAL OSAKA | アガベイベントナビ</title>
   <meta name="description" content="大阪で開催されるボタニカルイベント。多様な植物愛好家やショップが出店する2日間の即売会です。">
-  <meta name="keywords" content="BOTANICAL BOTANICAL OSAKA,即売会,大型,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="BOTANICAL BOTANICAL OSAKA,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="BOTANICAL BOTANICAL OSAKA | アガベイベントナビ">
   <meta property="og:description" content="大阪で開催されるボタニカルイベント。多様な植物愛好家やショップが出店する2日間の即売会です。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "BOTANICAL BOTANICAL OSAKA"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>大阪で開催されるボタニカルイベント。多様な植物愛好家やショップが出店する2日間の即売会です。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%A4%A7%E9%98%AA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -159,26 +155,21 @@
             <span class="info-value">大阪</span>
           </div>
           <div class="info-row">
-            <span class="info-label">入場料</span>
-            <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関西</span>
           </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTANICAL+BOTANICAL+OSAKA&dates=20260328%2F20260330&location=%E5%A4%A7%E9%98%AA" target="_blank" rel="noopener" class="gcal-btn">
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTANICAL%20BOTANICAL%20OSAKA&dates=20260328%2F20260330&location=%E5%A4%A7%E9%98%AA" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/botanical_botanical__/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@botanical_botanical__</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -218,7 +209,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'botanical-botanical-osaka';

--- a/events/botanical-botanical-tokyo-2026.html
+++ b/events/botanical-botanical-tokyo-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>東京で開催されるボタニカルイベント。多様な植物愛好家やショップが集まる即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTANICAL+BOTANICAL+TOKYO&dates=20260530%2F20260601&location=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BOTANICAL%20BOTANICAL%20TOKYO&dates=20260530%2F20260601&location=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'botanical-botanical-tokyo-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/botanical-marche-kanazawa-2026.html
+++ b/events/botanical-marche-kanazawa-2026.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/botanical-marche-kanazawa-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ボタニカルマルシェ金沢2026 | アガベイベントナビ</title>
-    <meta name="description" content="石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。">
-    <meta property="og:title" content="ボタニカルマルシェ金沢2026">
-    <meta property="og:description" content="石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/botanical-marche-kanazawa-2026.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt; ボタニカルマルシェ金沢2026</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>ボタニカルマルシェ金沢2026</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-09">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年05月09日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">石川県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>ボタニカルマルシェ金沢2026は石川県で開催される植物イベントです。石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=石川%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年05月09日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">石川県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=ボタニカルマルシェ金沢2026&dates=20260509%2F20260510&location=石川&details=ボタニカルマルシェ金沢2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/botanical-marche-kanazawa-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ボタニカルマルシェ金沢2026 | アガベイベントナビ</title>
+  <meta name="description" content="石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。">
+  <meta name="keywords" content="ボタニカルマルシェ金沢2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="ボタニカルマルシェ金沢2026 | アガベイベントナビ">
+  <meta property="og:description" content="石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/botanical-marche-kanazawa-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "ボタニカルマルシェ金沢2026",
-    "description": "石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。",
     "startDate": "2026-05-09",
-    "location": {
-        "@type": "Place",
-        "name": "金沢（会場未確定）",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "石川県",
-            "addressLocality": "金沢（会場未確定）"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-05-09",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "ボタニカルマルシェ金沢2026"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "石川県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "石川",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/botanical-marche-kanazawa-2026.html"
+    "description": "石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "ボタニカルマルシェ金沢2026"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "中部のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E9%83%A8"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "ボタニカルマルシェ金沢2026"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt;
+    <span>ボタニカルマルシェ金沢2026</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>ボタニカルマルシェ金沢2026</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-09" data-date-end="2026-05-09"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月9日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">石川</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>石川県金沢で開催されるボタニカルマルシェ。珍奇植物や多肉植物が揃うマルシェ。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E7%9F%B3%E5%B7%9D%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E7%9F%B3%E5%B7%9D%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月9日（土）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">石川県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">中部</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7%E9%87%91%E6%B2%A22026&dates=20260509%2F20260510&location=%E7%9F%B3%E5%B7%9D%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'botanical-marche-kanazawa-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/botanical-market-akita-2026.html
+++ b/events/botanical-market-akita-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>秋田県の道の駅うごで開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%86%E3%81%94%20%E7%AB%AF%E7%B8%AB%E3%81%84%E3%81%AE%E9%83%B7" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%86%E3%81%94%20%E7%AB%AF%E7%B8%AB%E3%81%84%E3%81%AE%E9%83%B7&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">東北</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88&dates=20260425%2F20260427&location=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%86%E3%81%94+%E7%AB%AF%E7%B8%AB%E3%81%84%E3%81%AE%E9%83%B7" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88&dates=20260425%2F20260427&location=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%86%E3%81%94%20%E7%AB%AF%E7%B8%AB%E3%81%84%E3%81%AE%E9%83%B7" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'botanical-market-akita-2026';

--- a/events/bromeliad-festa-spring-2026.html
+++ b/events/bromeliad-festa-spring-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BROMELIAD FESTA SPRING 2026 | アガベイベントナビ</title>
   <meta name="description" content="ブロメリア専門の即売会。">
-  <meta name="keywords" content="BROMELIAD FESTA SPRING 2026,即売会,ブロメリア,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="BROMELIAD FESTA SPRING 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="BROMELIAD FESTA SPRING 2026 | アガベイベントナビ">
   <meta property="og:description" content="ブロメリア専門の即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>ブロメリア専門の即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E6%9D%BF%E6%A9%8B%E5%8C%BA%E7%AB%8B%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -156,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BROMELIAD+FESTA+SPRING+2026&dates=20260405%2F20260406&location=%E6%9D%BF%E6%A9%8B%E5%8C%BA%E7%AB%8B%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BROMELIAD%20FESTA%20SPRING%202026&dates=20260405%2F20260406&location=%E6%9D%BF%E6%A9%8B%E5%8C%BA%E7%AB%8B%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'bromeliad-festa-spring-2026';

--- a/events/bts-beppu-taniku-show-2026.html
+++ b/events/bts-beppu-taniku-show-2026.html
@@ -13,17 +13,17 @@
   <link rel="canonical" href="https://agave-navi.com/events/bts-beppu-taniku-show-2026.html">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>BTS - BEPPU TANIKU SHOW | アガベイベントナビ</title>
-  <meta name="description" content="大分・別府公園で開催される多肉植物の展示即売会。別府の温泉地ならではのユニークな植物イベント。">
+  <meta name="description" content="大分県別府市で開催される多肉植物の即売会。">
   <meta name="keywords" content="BTS - BEPPU TANIKU SHOW,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="BTS - BEPPU TANIKU SHOW | アガベイベントナビ">
-  <meta property="og:description" content="大分・別府公園で開催される多肉植物の展示即売会。別府の温泉地ならではのユニークな植物イベント。">
+  <meta property="og:description" content="大分県別府市で開催される多肉植物の即売会。">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agave-navi.com/events/bts-beppu-taniku-show-2026.html">
   <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,18 +35,43 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "大分",
+      "name": "別府市内",
       "address": {
         "@type": "PostalAddress",
         "addressRegion": "大分",
         "addressCountry": "JP"
       }
     },
-    "description": "大分・別府公園で開催される多肉植物の展示即売会。別府の温泉地ならではのユニークな植物イベント。",
+    "description": "大分県別府市で開催される多肉植物の即売会。",
     "organizer": {
       "@type": "Organization",
       "name": "BTS - BEPPU TANIKU SHOW"
     }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "BTS - BEPPU TANIKU SHOW"
+      }
+    ]
   }
   </script>
 </head>
@@ -59,19 +84,19 @@
         <span class="logo-jp">アガベイベントナビ</span>
       </a>
       <div class="header-actions">
-      <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-        <span class="blob-bg"></span>
-        <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-        <span class="ikitai-label">行きたい</span>
-        <span class="ikitai-badge" id="ikitaiBadge"></span>
-      </a>
-    </div>
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
     </div>
   </header>
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="/">即売会一覧</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
     <span>BTS - BEPPU TANIKU SHOW</span>
   </nav>
 
@@ -80,9 +105,9 @@
       <h1>BTS - BEPPU TANIKU SHOW</h1>
       <div class="detail-meta">
         <span class="detail-status-badge" data-date="2026-04-18" data-date-end="2026-04-18"></span>
-        <span class="detail-meta-dot">&middot;</span>
+        <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月18日（土）</span>
-        <span class="detail-meta-dot">&middot;</span>
+        <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">大分</span>
       </div>
       <div class="detail-header-actions">
@@ -99,13 +124,22 @@
       <div class="detail-main">
         <div class="detail-section">
           <h2 class="detail-section-title">概要</h2>
-          <p>大分・別府公園で開催される多肉植物の展示即売会。別府の温泉地ならではのユニークな植物イベント。</p>
+          <p>大分県別府市で開催される多肉植物の即売会。</p>
         </div>
 
 
 
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%88%A5%E5%BA%9C%E5%B8%82%E5%86%85" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%88%A5%E5%BA%9C%E5%B8%82%E5%86%85&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
         <div class="detail-back">
-          <a href="/" class="detail-back-link">&larr; 即売会一覧に戻る</a>
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
       </div>
 
@@ -117,11 +151,17 @@
             <span class="info-value">2026年4月18日（土）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">別府市内</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BTS+-+BEPPU+TANIKU+SHOW&dates=20260418%2F20260419&location=%E5%A4%A7%E5%88%86" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=BTS%20-%20BEPPU%20TANIKU%20SHOW&dates=20260418%2F20260419&location=%E5%88%A5%E5%BA%9C%E5%B8%82%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -134,15 +174,18 @@
     </div>
   </main>
 
-  <div class="ad-slot ad-slot-article-bottom">
-    <div class="ad-affiliate-area" id="adAffiliateArea">
-      <div class="aff-slot" id="affSlot1"></div>
-      <div class="aff-slot" id="affSlot2"></div>
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
     </div>
   </div>
 
   <div class="correction-notice">
-    <p>掲載情報に誤りがある場合は<a href="/contact.html">お問い合わせ</a>よりご連絡ください。</p>
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
   </div>
 
   <footer class="footer">
@@ -163,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'bts-beppu-taniku-show-2026';
@@ -186,11 +229,10 @@
         btn.classList.remove('is-fav');
         label.textContent = '行きたい';
       }
-      const countEl = document.getElementById('ikitaiBadge');
-      if (countEl) countEl.textContent = favs.length;
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/chinki-shokubutsu-freemarket-machida-2026.html
+++ b/events/chinki-shokubutsu-freemarket-machida-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>東京都町田市のパリオで開催される珍奇植物のフリーマーケット。アガベや塊根植物の個人売買が楽しめる。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E7%94%BA%E7%94%B0%E3%83%91%E3%83%AA%E3%82%AA%204%E9%9A%8E" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E7%94%BA%E7%94%B0%E3%83%91%E3%83%AA%E3%82%AA%204%E9%9A%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%8F%8D%E5%A5%87%E6%A4%8D%E7%89%A9%E3%83%95%E3%83%AA%E3%83%BC%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88&dates=20260426%2F20260427&location=%E7%94%BA%E7%94%B0%E3%83%91%E3%83%AA%E3%82%AA+4%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%8F%8D%E5%A5%87%E6%A4%8D%E7%89%A9%E3%83%95%E3%83%AA%E3%83%BC%E3%83%9E%E3%83%BC%E3%82%B1%E3%83%83%E3%83%88&dates=20260426%2F20260427&location=%E7%94%BA%E7%94%B0%E3%83%91%E3%83%AA%E3%82%AA%204%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'chinki-shokubutsu-freemarket-machida-2026';

--- a/events/chinki-shokubutsu-ichiba-vol8-2026.html
+++ b/events/chinki-shokubutsu-ichiba-vol8-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>沖縄で開催される珍奇植物の即売会。アガベ・塊根植物・多肉植物など希少植物が集まる。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E8%A5%BF%E5%8E%9F%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7%20%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E5%BA%83%E5%A0%B4" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E8%A5%BF%E5%8E%9F%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7%20%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E5%BA%83%E5%A0%B4&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%8F%8D%E5%A5%87%E6%A4%8D%E7%89%A9%E5%B8%82%E5%A0%B4+Vol.8&dates=20260425%2F20260427&location=%E8%A5%BF%E5%8E%9F%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7+%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E5%BA%83%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%8F%8D%E5%A5%87%E6%A4%8D%E7%89%A9%E5%B8%82%E5%A0%B4%20Vol.8&dates=20260425%2F20260427&location=%E8%A5%BF%E5%8E%9F%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7%20%E3%81%95%E3%82%8F%E3%81%B5%E3%81%98%E5%BA%83%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'chinki-shokubutsu-ichiba-vol8-2026';

--- a/events/coco-et-nico-bond-project-2026.html
+++ b/events/coco-et-nico-bond-project-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>COCO ET NICO presents Bond PROJECT | アガベイベントナビ</title>
   <meta name="description" content="ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。">
-  <meta name="keywords" content="COCO ET NICO presents Bond PROJECT,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="COCO ET NICO presents Bond PROJECT,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="COCO ET NICO presents Bond PROJECT | アガベイベントナビ">
   <meta property="og:description" content="ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>ココニコ主催のアート×多肉植物イベント。市原湖畔美術館の美しいロケーションで開催。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B8%82%E5%8E%9F%E6%B9%96%E7%95%94%E7%BE%8E%E8%A1%93%E9%A4%A8" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E5%B8%82%E5%8E%9F%E6%B9%96%E7%95%94%E7%BE%8E%E8%A1%93%E9%A4%A8&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=COCO+ET+NICO+presents+Bond+PROJECT&dates=20260509%2F20260510&location=%E5%B8%82%E5%8E%9F%E6%B9%96%E7%95%94%E7%BE%8E%E8%A1%93%E9%A4%A8" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=COCO%20ET%20NICO%20presents%20Bond%20PROJECT&dates=20260509%2F20260510&location=%E5%B8%82%E5%8E%9F%E6%B9%96%E7%95%94%E7%BE%8E%E8%A1%93%E9%A4%A8" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'coco-et-nico-bond-project-2026';

--- a/events/collect-plants-vol2.html
+++ b/events/collect-plants-vol2.html
@@ -1,293 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/collect-plants-vol2.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Collect Plants Vol.2 | アガベイベントナビ</title>
-    <meta name="description" content="コレクターズアイテムとしての植物を一堂に集めるイベント。希少品種から限定アイテムまで。">
-    <meta property="og:title" content="Collect Plants Vol.2">
-    <meta property="og:description" content="コレクターズアイテムとしての植物を一堂に集めるイベント。希少品種から限定アイテムまで。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/collect-plants-vol2.html">
-    <meta property="og:image" content="https://collect-plants.com/cms/wp-content/uploads/2025/12/Vol.2-1.png">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt; Collect Plants Vol.2</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://collect-plants.com/cms/wp-content/uploads/2025/12/Vol.2-1.png" onerror="this.parentElement.style.display='none'" alt="Collect Plants Vol.2" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>Collect Plants Vol.2</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-09" data-date-end="2026-05-10">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月9日（土）-10日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">東京都</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>Collect Plants Vol.2は、コレクターズアイテムとしての植物を一堂に集めるイベントです。希少品種から限定アイテムまで、植物コレクターには見逃せない2日間。全国から優良なナーサリーやコレクターが出展し、普段は手に入らない植物が多数販売されます。</p>
-                    <p>Vol.1の成功を受けての第2回開催。前回以上の出展者数と希少品種が集まることが期待されています。アガベ、多肉植物、観葉植物など、様々なカテゴリの植物コレクションが揃います。</p>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年5月9日（土）-10日（日）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">調整中</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">エリア</span>
-                        <span class="info-value">東京都</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://collect-plants.com/event/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Collect+Plants+Vol.2&dates=20260509T100000%2F20260510T170000&location=%E3%82%B0%E3%83%A9%E3%83%B3%E3%83%A1%E3%83%83%E3%82%BB%E7%86%8A%E6%9C%AC%2C+%E7%86%8A%E6%9C%AC%E7%9C%8C&details=Collect+Plants+Vol.2+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/collect-plants-vol2.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Collect Plants Vol.2 | アガベイベントナビ</title>
+  <meta name="description" content="グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。">
+  <meta name="keywords" content="Collect Plants Vol.2,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="Collect Plants Vol.2 | アガベイベントナビ">
+  <meta property="og:description" content="グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/collect-plants-vol2.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "Collect Plants Vol.2",
-    "description": "グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。",
-    "startDate": "2026-05-09T09:00:00+09:00",
-    "endDate": "2026-05-10T17:00:00+09:00",
-    "image": "https://agave-navi.com/images/ogp/collect-plants-vol2.jpg",
-    "location": {
-        "@type": "Place",
-        "name": "グランメッセ熊本",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "東京県"
-        }
-    },
-    "organizer": {
-        "@type": "Organization",
-        "name": "Collect Plants Vol.2",
-        "url": "https://collect-plants.com/event/"
-    },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/collect-plants-vol2.html"
-    },
+    "startDate": "2026-05-09",
+    "endDate": "2026-05-10",
+    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
-    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode"
-}
-    </script>
+    "location": {
+      "@type": "Place",
+      "name": "調整中",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "熊本",
+        "addressCountry": "JP"
+      }
+    },
+    "description": "グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "Collect Plants Vol.2"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "九州のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B9%9D%E5%B7%9E"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "Collect Plants Vol.2"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E4%B9%9D%E5%B7%9E">九州のイベント</a> &gt;
+    <span>Collect Plants Vol.2</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>Collect Plants Vol.2</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-09" data-date-end="2026-05-10"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月9日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">熊本</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>グランメッセ熊本で開催。約150店舗が出店する九州最大の植物イベント。前回は約5,000人来場。</p>
+        </div>
 
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E8%AA%BF%E6%95%B4%E4%B8%AD" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E8%AA%BF%E6%95%B4%E4%B8%AD&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月9日（土） 〜 5月10日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">調整中</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">九州</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">未定</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Collect%20Plants%20Vol.2&dates=20260509%2F20260511&location=%E8%AA%BF%E6%95%B4%E4%B8%AD" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'collect-plants-vol2';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/enjoy-place-outside-tsukuba-2026.html
+++ b/events/enjoy-place-outside-tsukuba-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>enjoy place outside | アガベイベントナビ</title>
   <meta name="description" content="茨城県つくば市・つくば中央公園で2026年初開催の屋外マルシェ。植物・古道具・ガーデン雑貨など約102店が集結。植物ジャンル35店で多肉植物専門店も10店以上ラインナップ。雨天決行。">
-  <meta name="keywords" content="enjoy place outside,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="enjoy place outside,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="enjoy place outside | アガベイベントナビ">
   <meta property="og:description" content="茨城県つくば市・つくば中央公園で2026年初開催の屋外マルシェ。植物・古道具・ガーデン雑貨など約102店が集結。植物ジャンル35店で多肉植物専門店も10店以上ラインナップ。雨天決行。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "即売会イベント一覧",
-        "item": "https://agave-navi.com/category/sokubai.html"
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="../category/sokubai.html">即売会イベント一覧</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
     <span>enjoy place outside</span>
   </nav>
 
@@ -127,6 +127,8 @@
           <p>茨城県つくば市・つくば中央公園で2026年初開催の屋外マルシェ。植物・古道具・ガーデン雑貨など約102店が集結。植物ジャンル35店で多肉植物専門店も10店以上ラインナップ。雨天決行。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -135,8 +137,9 @@
           </div>
         </div>
 
+
         <div class="detail-back">
-          <a href="../category/sokubai.html" class="detail-back-link">即売会イベント一覧に戻る</a>
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
       </div>
 
@@ -151,20 +154,14 @@
             <span class="info-label">会場</span>
             <span class="info-value">つくば中央公園</span>
           </div>
-
-          <div class="info-row">
-            <span class="info-label">カテゴリ</span>
-            <span class="info-value">即売会,マルシェ</span>
-          </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
-          <div class="info-row">
-            <span class="info-label">公式サイト</span>
-            <span class="info-value"><a href="https://pukubook.jp/events/enjoy-place-outside-2026" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-          </div>
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=enjoy+place+outside&dates=20260516%2F20260517&location=%E3%81%A4%E3%81%8F%E3%81%B0%E4%B8%AD%E5%A4%AE%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=enjoy%20place%20outside&dates=20260516%2F20260517&location=%E3%81%A4%E3%81%8F%E3%81%B0%E4%B8%AD%E5%A4%AE%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -209,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'enjoy-place-outside-tsukuba-2026';

--- a/events/fuji-taniku-plants-marche-2026.html
+++ b/events/fuji-taniku-plants-marche-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>静岡県富士宮市の啓芳園で開催される多肉植物の即売マルシェ。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%95%93%E8%8A%B3%E5%9C%92" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E5%95%93%E8%8A%B3%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
@@ -154,6 +158,8 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">東海</span>
           </div>
+
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%AF%8C%E5%A3%AB%E5%A4%9A%E8%82%89%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260418%2F20260419&location=%E5%95%93%E8%8A%B3%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'fuji-taniku-plants-marche-2026';

--- a/events/fujisan-festa.html
+++ b/events/fujisan-festa.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FUJISAN FESTA | アガベイベントナビ</title>
   <meta name="description" content="静岡県富士市で開催される大型植物フェスタ。多肉植物やサボテンが豊富。">
-  <meta name="keywords" content="FUJISAN FESTA,即売会,大型,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="FUJISAN FESTA,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="FUJISAN FESTA | アガベイベントナビ">
   <meta property="og:description" content="静岡県富士市で開催される大型植物フェスタ。多肉植物やサボテンが豊富。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "静岡",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "静岡",
+        "addressRegion": "中部",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年5月3日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">静岡</span>
+        <span class="detail-meta-item">中部</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年5月3日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">中部</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=FUJISAN+FESTA&dates=20260503%2F20260504&location=%E9%9D%99%E5%B2%A1" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=FUJISAN%20FESTA&dates=20260503%2F20260504&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'fujisan-festa';

--- a/events/fukuoka-green-party-2026.html
+++ b/events/fukuoka-green-party-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FUKUOKA GREEN PARTY 2026 | アガベイベントナビ</title>
   <meta name="description" content="糸島市の志摩中央公園にて。多肉植物・コーデックス・ガーデニング資材。キッチンカーも出店。無料駐車場500台。">
-  <meta name="keywords" content="FUKUOKA GREEN PARTY 2026,マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="FUKUOKA GREEN PARTY 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="FUKUOKA GREEN PARTY 2026 | アガベイベントナビ">
   <meta property="og:description" content="糸島市の志摩中央公園にて。多肉植物・コーデックス・ガーデニング資材。キッチンカーも出店。無料駐車場500台。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "福岡",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "福岡",
+        "addressRegion": "九州",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年5月3日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">福岡</span>
+        <span class="detail-meta-item">九州</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年5月3日（日） 〜 5月4日（月）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=FUKUOKA+GREEN+PARTY+2026&dates=20260503%2F20260505&location=%E7%A6%8F%E5%B2%A1" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=FUKUOKA%20GREEN%20PARTY%202026&dates=20260503%2F20260505&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'fukuoka-green-party-2026';

--- a/events/fukuoka-green-party-6th-2026.html
+++ b/events/fukuoka-green-party-6th-2026.html
@@ -13,17 +13,17 @@
   <link rel="canonical" href="https://agave-navi.com/events/fukuoka-green-party-6th-2026.html">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>第6回 福岡グリーンパーティー | アガベイベントナビ</title>
-  <meta name="description" content="福岡県糸島市・志摩中央公園で開催されるアガベ・塊根植物・珍奇植物の即売会。10:00〜16:00開催。GW期間中の九州最大級の植物イベント。">
+  <meta name="description" content="福岡県糸島市・志摩中央公園で開催される園芸イベント第6回。「グリパ」の愛称で知られる屋外型植物マーケット。アガベ・塊根植物・多肉植物を扱う店舗とフード出店が集結。">
   <meta name="keywords" content="第6回 福岡グリーンパーティー,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="第6回 福岡グリーンパーティー | アガベイベントナビ">
-  <meta property="og:description" content="福岡県糸島市・志摩中央公園で開催されるアガベ・塊根植物・珍奇植物の即売会。10:00〜16:00開催。GW期間中の九州最大級の植物イベント。">
+  <meta property="og:description" content="福岡県糸島市・志摩中央公園で開催される園芸イベント第6回。「グリパ」の愛称で知られる屋外型植物マーケット。アガベ・塊根植物・多肉植物を扱う店舗とフード出店が集結。">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agave-navi.com/events/fukuoka-green-party-6th-2026.html">
   <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -42,7 +42,7 @@
         "addressCountry": "JP"
       }
     },
-    "description": "福岡県糸島市・志摩中央公園で開催されるアガベ・塊根植物・珍奇植物の即売会。10:00〜16:00開催。GW期間中の九州最大級の植物イベント。",
+    "description": "福岡県糸島市・志摩中央公園で開催される園芸イベント第6回。「グリパ」の愛称で知られる屋外型植物マーケット。アガベ・塊根植物・多肉植物を扱う店舗とフード出店が集結。",
     "organizer": {
       "@type": "Organization",
       "name": "第6回 福岡グリーンパーティー"
@@ -124,7 +124,7 @@
       <div class="detail-main">
         <div class="detail-section">
           <h2 class="detail-section-title">概要</h2>
-          <p>福岡県糸島市・志摩中央公園で開催されるアガベ・塊根植物・珍奇植物の即売会。10:00〜16:00開催。GW期間中の九州最大級の植物イベント。</p>
+          <p>福岡県糸島市・志摩中央公園で開催される園芸イベント第6回。「グリパ」の愛称で知られる屋外型植物マーケット。アガベ・塊根植物・多肉植物を扱う店舗とフード出店が集結。</p>
         </div>
 
         <div class="detail-section detail-instagram-embed">
@@ -135,6 +135,7 @@
           <p class="instagram-embed-link"><a href="https://www.instagram.com/p/DTH4ktKEhUq/" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
         </div>
 
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -142,6 +143,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%BF%97%E6%91%A9%E4%B8%AD%E5%A4%AE%E5%85%AC%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
@@ -153,7 +155,7 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年5月3日（日） 〜 5月4日（月）</span>
+            <span class="info-value">2026年5月3日（日） 〜 5月4日（月） 10:00〜16:00</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
@@ -163,8 +165,16 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">九州</span>
           </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">時間</span>
+            <span class="info-value">10:00〜16:00</span>
+          </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC6%E5%9B%9E+%E7%A6%8F%E5%B2%A1%E3%82%B0%E3%83%AA%E3%83%BC%E3%83%B3%E3%83%91%E3%83%BC%E3%83%86%E3%82%A3%E3%83%BC&dates=20260503%2F20260505&location=%E5%BF%97%E6%91%A9%E4%B8%AD%E5%A4%AE%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC6%E5%9B%9E%20%E7%A6%8F%E5%B2%A1%E3%82%B0%E3%83%AA%E3%83%BC%E3%83%B3%E3%83%91%E3%83%BC%E3%83%86%E3%82%A3%E3%83%BC&dates=20260503%2F20260505&location=%E5%BF%97%E6%91%A9%E4%B8%AD%E5%A4%AE%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -209,7 +219,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'fukuoka-green-party-6th-2026';

--- a/events/fumakilla-kadan-fes-2026.html
+++ b/events/fumakilla-kadan-fes-2026.html
@@ -1,290 +1,244 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/fumakilla-kadan-fes-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>フマキラーカダンフェス | アガベイベントナビ</title>
-    <meta name="description" content="大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。">
-    <meta property="og:title" content="フマキラーカダンフェス">
-    <meta property="og:description" content="大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/fumakilla-kadan-fes-2026.html">
-    <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; フマキラーカダンフェス</div>
-
-    <main class="detail-page">
-        </div>
-        <div class="detail-header">
-            <h1>フマキラーカダンフェス</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-03-16" data-date-end="2026-04-26">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年4月25日（土）-26日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">大阪</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=ABC%E3%83%8F%E3%82%A6%E3%82%B8%E3%83%B3%E3%82%B0%20%E3%82%A6%E3%82%A7%E3%83%AB%E3%83%93%E3%83%BC%E3%81%BF%E3%81%AE%E3%81%8A%2C%E5%A4%A7%E9%98%AA&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年4月25日（土）-26日（日）<br>10:00〜17:00</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">ABCハウジング ウェルビーみのお</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">開催地域</span>
-                        <span class="info-value">関西</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://www.fumakilla.co.jp/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%95%E3%83%9E%E3%82%AD%E3%83%A9%E3%83%BC%E3%82%AB%E3%83%80%E3%83%B3%E3%83%95%E3%82%A7%E3%82%B9&dates=20260425T090000%2F20260426T170000&location=ABC%E3%83%8F%E3%82%A6%E3%82%B8%E3%83%B3%E3%82%B0%20%E3%82%A6%E3%82%A7%E3%83%AB%E3%83%93%E3%83%BC%E3%81%BF%E3%81%AE%E3%81%8A&details=%E3%83%95%E3%83%9E%E3%82%AD%E3%83%A9%E3%83%BC%E3%82%AB%E3%83%80%E3%83%B3%E3%83%95%E3%82%A7%E3%82%B9+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/fumakilla-kadan-fes-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>フマキラーカダンフェス | アガベイベントナビ</title>
+  <meta name="description" content="大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。">
+  <meta name="keywords" content="フマキラーカダンフェス,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="フマキラーカダンフェス | アガベイベントナビ">
+  <meta property="og:description" content="大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/fumakilla-kadan-fes-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "フマキラーカダンフェス",
-    "description": "大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。",
-    "startDate": "2026-04-25T10:00:00+09:00",
-    "endDate": "2026-04-26T17:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "ABCハウジング ウェルビーみのお",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "大阪"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-03-16",
+    "endDate": "2026-04-26",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/fumakilla-kadan-fes-2026.html"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "ABCハウジング ウェルビーみのお",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "大阪",
+        "addressCountry": "JP"
+      }
+    },
+    "description": "大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "フマキラーカダンフェス"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "フマキラーカダンフェス"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
+    <span>フマキラーカダンフェス</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>フマキラーカダンフェス</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-03-16" data-date-end="2026-04-26"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年3月16日（月）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">大阪</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>大阪・箕面のABCハウジングで開催されるフマキラー主催の植物フェス。多肉植物やガーデニング用品の販売。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=ABC%E3%83%8F%E3%82%A6%E3%82%B8%E3%83%B3%E3%82%B0%20%E3%82%A6%E3%82%A7%E3%83%AB%E3%83%93%E3%83%BC%E3%81%BF%E3%81%AE%E3%81%8A%2C%E5%A4%A7%E9%98%AA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=ABC%E3%83%8F%E3%82%A6%E3%82%B8%E3%83%B3%E3%82%B0%20%E3%82%A6%E3%82%A7%E3%83%AB%E3%83%93%E3%83%BC%E3%81%BF%E3%81%AE%E3%81%8A%2C%E5%A4%A7%E9%98%AA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年3月16日（月） 〜 4月26日（日） 10:00〜17:00</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">ABCハウジング ウェルビーみのお</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">時間</span>
+            <span class="info-value">10:00〜17:00</span>
+          </div>
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%95%E3%83%9E%E3%82%AD%E3%83%A9%E3%83%BC%E3%82%AB%E3%83%80%E3%83%B3%E3%83%95%E3%82%A7%E3%82%B9&dates=20260316%2F20260427&location=ABC%E3%83%8F%E3%82%A6%E3%82%B8%E3%83%B3%E3%82%B0%20%E3%82%A6%E3%82%A7%E3%83%AB%E3%83%93%E3%83%BC%E3%81%BF%E3%81%AE%E3%81%8A" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'fumakilla-kadan-fes-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/fushimi-daisakusen-vol2.html
+++ b/events/fushimi-daisakusen-vol2.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/fushimi-daisakusen-vol2.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>伏見大作戦 vol.2 | アガベイベントナビ</title>
-    <meta name="description" content="京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。">
-    <meta property="og:title" content="伏見大作戦 vol.2">
-    <meta property="og:description" content="京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/fushimi-daisakusen-vol2.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; 伏見大作戦 vol.2</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>伏見大作戦 vol.2</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-16">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年05月16日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">京都県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>伏見大作戦 vol.2は京都県で開催される植物イベントです。京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=京都%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年05月16日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">京都県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=伏見大作戦 vol.2&dates=20260516%2F20260517&location=京都&details=伏見大作戦 vol.2+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/fushimi-daisakusen-vol2.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>伏見大作戦 vol.2 | アガベイベントナビ</title>
+  <meta name="description" content="京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。">
+  <meta name="keywords" content="伏見大作戦 vol.2,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="伏見大作戦 vol.2 | アガベイベントナビ">
+  <meta property="og:description" content="京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/fushimi-daisakusen-vol2.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "伏見大作戦 vol.2",
-    "description": "京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。",
     "startDate": "2026-05-16",
-    "location": {
-        "@type": "Place",
-        "name": "三谷商事株式会社 屋外スペース",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "京都県",
-            "addressLocality": "三谷商事株式会社 屋外スペース"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-05-16",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "伏見大作戦 vol.2"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "京都県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "京都",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/fushimi-daisakusen-vol2.html"
+    "description": "京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "伏見大作戦 vol.2"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "伏見大作戦 vol.2"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
+    <span>伏見大作戦 vol.2</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>伏見大作戦 vol.2</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-16" data-date-end="2026-05-16"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月16日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">京都</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>京都・伏見で開催される植物即売会。地域の植物愛好家が集まるイベント。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%AC%E9%83%BD%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E4%BA%AC%E9%83%BD%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月16日（土）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">京都県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E4%BC%8F%E8%A6%8B%E5%A4%A7%E4%BD%9C%E6%88%A6%20vol.2&dates=20260516%2F20260517&location=%E4%BA%AC%E9%83%BD%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'fushimi-daisakusen-vol2';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/futakotamagawa-botanical-2026.html
+++ b/events/futakotamagawa-botanical-2026.html
@@ -1,294 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/futakotamagawa-botanical-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>二子玉川ボタニカルフェスタ 2026春 | アガベイベントナビ</title>
-    <meta name="description" content="関東最大級の春の植物イベント。100以上の出展者が集結、アガベ、多肉植物の最新品種や希少種など。">
-    <meta property="og:title" content="二子玉川ボタニカルフェスタ 2026春">
-    <meta property="og:description" content="関東最大級の春の植物イベント。100以上の出展者が集結、アガベ、多肉植物の最新品種や希少種など。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/futakotamagawa-botanical-2026.html">
-    <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; 二子玉川ボタニカルフェスタ 2026春</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>二子玉川ボタニカルフェスタ 2026春</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-07" data-date-end="2026-04-05">もうすぐ</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年4月4日（土）-5日（日）10:00～18:00</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">東京都</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>二子玉川ボタニカルフェスタは、関東最大級の植物イベントとして知られる春の注目イベントです。二子玉川ライズの広大なスペースに100以上の出展者が集結。最新のアガベ品種から、世界的に希少な多肉植物、花関連商品や園芸用品まで、植物に関するあらゆるアイテムが揃います。2日間の開催で、ゆったりと回りながらお気に入りを見つけることができます。</p>
-                    <p>イベントの特徴は、販売だけでなく、業界をリードする植物専門家によるトークショーやワークショップが定期的に開催されること。アガベの育て方、多肉植物の越冬テクニック、アレンジメントの楽しみ方など、実践的な知識を直接学べます。初心者向けから上級者向けまで、どのレベルの愛好家でも参加できるセッションが用意されています。</p>
-                    <p>春の日差しを浴びながら、新しい植物との出会いや愛好家同士の交流を楽しめます。立地の良さから、周辺のカフェやショップも利用でき、ボタニカルライフスタイルを丸一日満喫できるイベントです。希少品種は早い段階で売り切れることもあるため、早めの来場をおすすめします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=二子玉川ライズ,東京都世田谷区&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年4月4日（土）-5日（日）<br>10:00～18:00</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">二子玉川ライズ</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">エリア</span>
-                        <span class="info-value">東京都世田谷区</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">500円（税込）</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF+2026%E6%98%A5&dates=20260404T100000%2F20260405T170000&location=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%A9%E3%82%A4%E3%82%BA%2C+%E6%9D%B1%E4%BA%AC%E9%83%BD&details=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF+2026%E6%98%A5+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,展示会,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/futakotamagawa-botanical-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>二子玉川ボタニカルフェスタ 2026春 | アガベイベントナビ</title>
+  <meta name="description" content="二子玉川ライズで開催される都市型ボタニカルイベント。展示・即売会・ワークショップが同時開催。">
+  <meta name="keywords" content="二子玉川ボタニカルフェスタ 2026春,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="二子玉川ボタニカルフェスタ 2026春 | アガベイベントナビ">
+  <meta property="og:description" content="二子玉川ライズで開催される都市型ボタニカルイベント。展示・即売会・ワークショップが同時開催。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/futakotamagawa-botanical-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "二子玉川ボタニカルフェスタ 2026春",
-    "description": "東京・二子玉川ライズで開催される春の大型植物イベント。アガベ、多肉植物、希少種から園芸用品まで、約100以上の出店者が集結。",
-    "startDate": "2026-04-04T10:00:00+09:00",
-    "endDate": "2026-04-05T18:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "二子玉川ライズ",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "東京都",
-            "addressLocality": "世田谷区",
-            "streetAddress": "玉川"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-05-07",
+    "endDate": "2026-04-05",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/futakotamagawa-botanical-2026.html"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "二子玉川ライズ",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "東京",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/futakotamagawa-botanical-2026.jpg",
+    "description": "二子玉川ライズで開催される都市型ボタニカルイベント。展示・即売会・ワークショップが同時開催。",
     "organizer": {
-        "@type": "Organization",
-        "name": "二子玉川ボタニカルフェスタ 2026春",
-        "url": "https://www.rise.sc/"
+      "@type": "Organization",
+      "name": "二子玉川ボタニカルフェスタ 2026春"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "二子玉川ボタニカルフェスタ 2026春"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>二子玉川ボタニカルフェスタ 2026春</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>二子玉川ボタニカルフェスタ 2026春</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-07" data-date-end="2026-04-05"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月7日（木）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">東京</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>二子玉川ライズで開催される都市型ボタニカルイベント。展示・即売会・ワークショップが同時開催。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%A9%E3%82%A4%E3%82%BA%2C%E6%9D%B1%E4%BA%AC%E9%83%BD%E4%B8%96%E7%94%B0%E8%B0%B7%E5%8C%BA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%A9%E3%82%A4%E3%82%BA%2C%E6%9D%B1%E4%BA%AC%E9%83%BD%E4%B8%96%E7%94%B0%E8%B0%B7%E5%8C%BA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月7日（木） 〜 4月5日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">二子玉川ライズ</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">500円（税込）</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%9C%E3%82%BF%E3%83%8B%E3%82%AB%E3%83%AB%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF%202026%E6%98%A5&dates=20260507%2F20260406&location=%E4%BA%8C%E5%AD%90%E7%8E%89%E5%B7%9D%E3%83%A9%E3%82%A4%E3%82%BA" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'futakotamagawa-botanical-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/gotanda-big-bazaar-2026-05.html
+++ b/events/gotanda-big-bazaar-2026-05.html
@@ -1,309 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/gotanda-big-bazaar-2026-05.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>サボテン・多肉植物ビッグバザール（5月） | アガベイベントナビ</title>
-    <meta name="description" content="国際多肉植物協会（ISIJ）主催。日本最大級のサボテン・多肉植物即売会。全国のトップ生産者やコレクターが出品。">
-    <meta property="og:title" content="サボテン・多肉植物ビッグバザール（5月）">
-    <meta property="og:description" content="国際多肉植物協会（ISIJ）主催。日本最大級のサボテン・多肉植物即売会。全国のトップ生産者やコレクターが出品。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/gotanda-big-bazaar-2026-05.html">
-    <meta property="og:image" content="http://isij.net/20.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; サボテン・多肉植物ビッグバザール（5月）</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="http://isij.net/20.jpg" onerror="this.parentElement.style.display='none'" alt="サボテン・多肉植物ビッグバザール" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>サボテン・多肉植物ビッグバザール（5月）</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-24">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月25日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">東京都品川区</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>国際多肉植物協会（ISIJ）主催による日本最大級のサボテン・多肉植物即売会です。年6回（1月・3月・5月・7月・9月・11月の奇数月）開催されており、全国のトップ生産者やコレクターが出品します。</p>
-                    <p>会場にはアガベ、ハオルチア、コーデックスなど希少品種が多数出揃い、植物好きにとって欠かせないイベント。多くの出店者から珍しい品種を発見できる絶好の機会です。</p>
-                    <p>このビッグバザールは国内で最も大規模なサボテン・多肉植物の即売会として知られており、毎回多くの愛好家が訪れます。レアな品種を探している方、コレクションを増やしたい方にとって最高の場所です。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=五反田TOCビル,東京都品川区西五反田7-22-17&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年5月25日（日）<br>奇数月の日曜日開催<br>9:45開場</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">五反田TOCビル 13階</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">東京都品川区西五反田7-22-17</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">500円</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">開催頻度</span>
-                        <span class="info-value">年6回（奇数月）開催</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">主催</span>
-                        <span class="info-value">国際多肉植物協会（ISIJ）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="http://isij.net/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260501T090000%2F20260501T160000&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2C+%E6%9D%B1%E4%BA%AC%E9%83%BD&details=%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/gotanda-big-bazaar-2026-05.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>サボテン・多肉植物ビッグバザール | アガベイベントナビ</title>
+  <meta name="description" content="ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。">
+  <meta name="keywords" content="サボテン・多肉植物ビッグバザール,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="サボテン・多肉植物ビッグバザール | アガベイベントナビ">
+  <meta property="og:description" content="ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/gotanda-big-bazaar-2026-05.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": "サボテン・多肉植物ビッグバザール（5月）",
-    "description": "国際多肉植物協会（ISIJ）主催の日本最大級のサボテン・多肉植物即売会。全国のトップ生産者やコレクターが出品。",
-    "startDate": "2026-05-31T09:45:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "五反田TOCビル 13階",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "東京都",
-            "addressLocality": "品川区",
-            "streetAddress": "西五反田7-22-17"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "name": "サボテン・多肉植物ビッグバザール",
+    "startDate": "2026-05-24",
+    "endDate": "2026-05-24",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": false,
-    "organizer": {
-        "@type": "Organization",
-        "name": "サボテン・多肉植物ビッグバザール",
-        "url": "http://isij.net/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "五反田TOCビル 13階",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "東京",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/gotanda-big-bazaar-2026-05.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "500",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/gotanda-big-bazaar-2026-05.html"
+    "description": "ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "サボテン・多肉植物ビッグバザール"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "サボテン・多肉植物ビッグバザール"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>サボテン・多肉植物ビッグバザール</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>サボテン・多肉植物ビッグバザール</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-24" data-date-end=""></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月24日（日）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">東京</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>ISIJ主催。五反田TOCビル13階で年6回（奇数月）開催。入場500円。整理券制で9:20頃から配布開始。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2C%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%93%81%E5%B7%9D%E5%8C%BA%E8%A5%BF%E4%BA%94%E5%8F%8D%E7%94%B07-22-17" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2C%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%93%81%E5%B7%9D%E5%8C%BA%E8%A5%BF%E4%BA%94%E5%8F%8D%E7%94%B07-22-17&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月24日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">五反田TOCビル 13階</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">500円</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260524%2F20260525&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'gotanda-big-bazaar-2026-05';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/green-breeze-fes-vol3.html
+++ b/events/green-breeze-fes-vol3.html
@@ -1,298 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/green-breeze-fes-vol3.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GREEN BREEZE FES vol.3 | アガベイベントナビ</title>
-    <meta name="description" content="和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめる。">
-    <meta property="og:title" content="GREEN BREEZE FES vol.3">
-    <meta property="og:description" content="和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめる。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/green-breeze-fes-vol3.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; GREEN BREEZE FES vol.3</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>GREEN BREEZE FES vol.3</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-31">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月31日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">和歌山市 本町公園</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>和歌山市の本町公園で開催されるGREEN BREEZE FES vol.3は、好評を博しているグリーンイベントの第3弾です。植物販売とワークショップを兼ね備えたイベントとして、多くの植物愛好家から注目されています。</p>
-                    <p>本イベントは単なる販売の場ではなく、ワークショップを通じて植物との関わり方を学べる体験型のイベントです。寄せ植えやアレンジメント、その他の植物関連ワークショップが用意され、初心者から上級者まで参加できます。</p>
-                    <p>公園という開放的な場所での開催により、家族連れでも楽しめる雰囲気になっています。春から初夏への季節の移ろいを感じながら、グリーンライフを満喫できる一日になるでしょう。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=%E5%92%8C%E6%AD%8C%E5%B1%B1%E5%B8%82%E5%8C%97%E6%A1%B6%E5%B1%8B%E7%94%BA%E6%9C%AC%E7%94%BA%E5%85%AC%E5%9C%92&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年5月31日（日）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">本町公園</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">和歌山市北桶屋町</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GREEN+BREEZE+FES+vol.3&dates=20260531%2F20260601&location=%E5%92%8C%E6%AD%8C%E5%B1%B1%E5%B8%82&details=GREEN+BREEZE+FES+vol.3+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                <div class="detail-instagram-card">
-                    <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-                    <a href="https://www.instagram.com/green_breeze_fes/" target="_blank" rel="noopener" class="instagram-account-link">
-                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-                        <span class="ig-gradient">@green_breeze_fes</span>
-                    </a>
-                </div>
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/green-breeze-fes-vol3.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GREEN BREEZE FES vol.3 | アガベイベントナビ</title>
+  <meta name="description" content="和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめます。">
+  <meta name="keywords" content="GREEN BREEZE FES vol.3,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="GREEN BREEZE FES vol.3 | アガベイベントナビ">
+  <meta property="og:description" content="和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめます。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/green-breeze-fes-vol3.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "GREEN BREEZE FES vol.3",
-    "description": "和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめる。",
     "startDate": "2026-05-31",
-    "location": {
-        "@type": "Place",
-        "name": "本町公園",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "和歌山県",
-            "addressLocality": "和歌山市",
-            "streetAddress": "北桶屋町"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-05-31",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/green-breeze-fes-vol3.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "GREEN BREEZE FES vol.3",
-        "url": "https://www.instagram.com/green_breeze_fes/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "本町公園",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "和歌山",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/green-breeze-fes-vol3.html"
+    "description": "和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめます。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "GREEN BREEZE FES vol.3"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "GREEN BREEZE FES vol.3"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
+    <span>GREEN BREEZE FES vol.3</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>GREEN BREEZE FES vol.3</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-31" data-date-end="2026-05-31"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月31日（日）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">和歌山</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>和歌山市の本町公園で開催されるグリーンイベント第3弾。植物販売やワークショップを楽しめます。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%92%8C%E6%AD%8C%E5%B1%B1%E5%B8%82%E5%8C%97%E6%A1%B6%E5%B1%8B%E7%94%BA%E6%9C%AC%E7%94%BA%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%92%8C%E6%AD%8C%E5%B1%B1%E5%B8%82%E5%8C%97%E6%A1%B6%E5%B1%8B%E7%94%BA%E6%9C%AC%E7%94%BA%E5%85%AC%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月31日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">本町公園</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GREEN%20BREEZE%20FES%20vol.3&dates=20260531%2F20260601&location=%E6%9C%AC%E7%94%BA%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'green-breeze-fes-vol3';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/greensnap-marche-hiroshima-2026.html
+++ b/events/greensnap-marche-hiroshima-2026.html
@@ -1,302 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/greensnap-marche-hiroshima-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GreenSnap Marche HIROSHIMA 2026 | アガベイベントナビ</title>
-    <meta name="description" content="広島市内で開催されるGreenSnap Marche HIROSHIMA 2026。GreenSnap主催の植物マルシェ。植物・ガーデニング雑貨・ワークショップ・キッチンカーなど。">
-    <meta property="og:title" content="GreenSnap Marche HIROSHIMA 2026">
-    <meta property="og:description" content="広島市内で開催されるGreenSnap Marche HIROSHIMA 2026。GreenSnap主催の植物マルシェ。植物・ガーデニング雑貨・ワークショップ・キッチンカーなど。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/greensnap-marche-hiroshima-2026.html">
-    <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt; GreenSnap Marche HIROSHIMA 2026</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>GreenSnap Marche HIROSHIMA 2026</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-23" data-date-end="2026-05-24">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月23日（土）-24日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">広島県広島市</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>GreenSnap Marche HIROSHIMA 2026は、GreenSnap主催による植物マルシェの広島版です。日本最大級の植物コミュニティが全国展開するイベントが、広島市内で開催されます。</p>
-                    <p>植物、ガーデニング雑貨、ワークショップ、キッチンカーなど、植物ライフスタイルを楽しむためのコンテンツが屋外で充実。多くの人気ショップやクリエイターが出店し、珍しい植物との出会いが期待できます。</p>
-                    <p>広島での初開催となる本イベント。植物愛好家が一堂に集まる、春から初夏への季節の変わり目を彩る充実のイベント内容。入場無料でお楽しみいただけます。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=広島市&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">5月23日（土）-24日（日）<br>10:00〜17:00（最終日16:00まで）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">広島市内（会場未確定）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">広島県広島市</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">主催</span>
-                        <span class="info-value">GreenSnap</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">ステータス</span>
-                        <span class="info-value">開催予定</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GreenSnap+Marche+HIROSHIMA+2026&dates=20260523T100000%2F20260524T170000&location=%E5%BA%83%E5%B3%B6%E7%9C%8C&details=GreenSnap+Marche+HIROSHIMA+2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/greensnap-marche-hiroshima-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GreenSnap Marche HIROSHIMA 2026 | アガベイベントナビ</title>
+  <meta name="description" content="GreenSnap主催の植物マルシェ広島版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。">
+  <meta name="keywords" content="GreenSnap Marche HIROSHIMA 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="GreenSnap Marche HIROSHIMA 2026 | アガベイベントナビ">
+  <meta property="og:description" content="GreenSnap主催の植物マルシェ広島版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/greensnap-marche-hiroshima-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "GreenSnap Marche HIROSHIMA 2026",
-    "description": "広島市内で開催されるGreenSnap主催の植物マルシェ。植物・ガーデニング雑貨・ワークショップ・キッチンカーなど屋外で楽しめるイベント。",
-    "startDate": "2026-05-23T10:00:00+09:00",
-    "endDate": "2026-05-24T16:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "広島市内",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "広島県",
-            "addressLocality": "広島市"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-05-23",
+    "endDate": "2026-05-24",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "organizer": {
-        "@type": "Organization",
-        "name": "GreenSnap Marche HIROSHIMA 2026",
-        "url": "https://greensnap.jp/event/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "広島市内（会場未確定）",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "広島",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/greensnap-marche-hiroshima-2026.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/greensnap-marche-hiroshima-2026.html"
+    "description": "GreenSnap主催の植物マルシェ広島版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "GreenSnap Marche HIROSHIMA 2026"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "中国のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E5%9B%BD"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "GreenSnap Marche HIROSHIMA 2026"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt;
+    <span>GreenSnap Marche HIROSHIMA 2026</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>GreenSnap Marche HIROSHIMA 2026</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-23" data-date-end="2026-05-24"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月23日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">広島</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>GreenSnap主催の植物マルシェ広島版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%BA%83%E5%B3%B6%E5%B8%82" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%BA%83%E5%B3%B6%E5%B8%82&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月23日（土） 〜 5月24日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">広島市内（会場未確定）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">中国</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GreenSnap%20Marche%20HIROSHIMA%202026&dates=20260523%2F20260525&location=%E5%BA%83%E5%B3%B6%E5%B8%82%E5%86%85%EF%BC%88%E4%BC%9A%E5%A0%B4%E6%9C%AA%E7%A2%BA%E5%AE%9A%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'greensnap-marche-hiroshima-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/greensnap-marche-toyosu-2026.html
+++ b/events/greensnap-marche-toyosu-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GreenSnap Marche 豊洲 2026 | アガベイベントナビ</title>
   <meta name="description" content="GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。">
-  <meta name="keywords" content="GreenSnap Marche 豊洲 2026,マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="GreenSnap Marche 豊洲 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="GreenSnap Marche 豊洲 2026 | アガベイベントナビ">
   <meta property="og:description" content="GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>GreenSnap主催の植物マルシェ豊洲版。植物・ガーデニング雑貨・ワークショップ・キッチンカーが集結。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E8%B1%8A%E6%B4%B2%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E8%B1%8A%E6%B4%B2%E5%85%AC%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GreenSnap+Marche+%E8%B1%8A%E6%B4%B2+2026&dates=20260606%2F20260608&location=%E8%B1%8A%E6%B4%B2%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GreenSnap%20Marche%20%E8%B1%8A%E6%B4%B2%202026&dates=20260606%2F20260608&location=%E8%B1%8A%E6%B4%B2%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'greensnap-marche-toyosu-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/greensnap-marche-yokohama-2026.html
+++ b/events/greensnap-marche-yokohama-2026.html
@@ -1,309 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/greensnap-marche-yokohama-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GreenSnap Marche YOKOHAMA 2026 | アガベイベントナビ</title>
-    <meta name="description" content="山下公園で開催されるGreenSnap Marche YOKOHAMA 2026。日本最大級の植物コミュニティが主催する大型マルシェ。全国の人気ショップやクリエイターが出店。">
-    <meta property="og:title" content="GreenSnap Marche YOKOHAMA 2026">
-    <meta property="og:description" content="山下公園で開催されるGreenSnap Marche YOKOHAMA 2026。日本最大級の植物コミュニティが主催する大型マルシェ。全国の人気ショップやクリエイターが出店。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/greensnap-marche-yokohama-2026.html">
-    <meta property="og:image" content="https://greensnap.jp/event/wp-content/themes/gs-events/images/ogp.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; GreenSnap Marche YOKOHAMA 2026</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://greensnap.jp/event/wp-content/themes/gs-events/images/ogp.jpg" onerror="this.parentElement.style.display='none'" alt="GreenSnap Marche YOKOHAMA 2026" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>GreenSnap Marche YOKOHAMA 2026</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-11" data-date-end="2026-04-12">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年4月11日（土）-12日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">神奈川県横浜市</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>GreenSnap Marche YOKOHAMA 2026は、山下公園で開催される日本最大級の植物マルシェです。日本最大級の植物コミュニティ「GreenSnap」が主催し、全国から選りすぐりの人気ショップやクリエイターが出店します。</p>
-                    <p>植物の販売だけでなく、ガーデニング雑貨、ワークショップ、キッチンカーなど、多彩なコンテンツが揃います。植物愛好家が一堂に集まる、春のビッグイベントです。</p>
-                    <p>横浜の美しい景観を背景に、植物、ガーデニング、ライフスタイルの魅力を体験できる充実の2日間。お友達やご家族と楽しめるイベント内容となっています。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=山下公園,横浜市中区&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">4月11日（土） 10:00〜17:00<br>4月12日（日） 10:00〜16:00</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">山下公園 おまつり広場</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">神奈川県横浜市中区</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">主催</span>
-                        <span class="info-value">GreenSnap</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">ステータス</span>
-                        <span class="info-value">開催予定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://greensnap.jp/event/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GreenSnap+Marche+YOKOHAMA+2026&dates=20260411T100000%2F20260412T170000&location=%E5%B1%B1%E4%B8%8B%E5%85%AC%E5%9C%92%E3%81%8A%E3%81%BE%E3%81%A4%E3%82%8A%E5%BA%83%E5%A0%B4%2C+%E6%A8%AA%E6%B5%9C%E5%B8%82&details=GreenSnap+Marche+YOKOHAMA+2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ,大型,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/greensnap-marche-yokohama-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GreenSnap Marche YOKOHAMA 2026 | アガベイベントナビ</title>
+  <meta name="description" content="日本最大級の植物コミュニティ「GreenSnap」主催。山下公園おまつり広場にて。前回は約4万人来場。入場無料。">
+  <meta name="keywords" content="GreenSnap Marche YOKOHAMA 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="GreenSnap Marche YOKOHAMA 2026 | アガベイベントナビ">
+  <meta property="og:description" content="日本最大級の植物コミュニティ「GreenSnap」主催。山下公園おまつり広場にて。前回は約4万人来場。入場無料。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/greensnap-marche-yokohama-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "GreenSnap Marche YOKOHAMA 2026",
-    "description": "山下公園で開催される日本最大級の植物マルシェ。全国の人気ショップやクリエイターが出店。植物・ガーデニング雑貨・ワークショップ・キッチンカーなど。",
-    "startDate": "2026-04-11T10:00:00+09:00",
-    "endDate": "2026-04-12T16:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "山下公園 おまつり広場",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "神奈川県",
-            "addressLocality": "横浜市中区"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-04-11",
+    "endDate": "2026-04-12",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "organizer": {
-        "@type": "Organization",
-        "name": "GreenSnap Marche YOKOHAMA 2026",
-        "url": "https://greensnap.jp/event/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "山下公園 おまつり広場",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "神奈川",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/greensnap-marche-yokohama-2026.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/greensnap-marche-yokohama-2026.html"
+    "description": "日本最大級の植物コミュニティ「GreenSnap」主催。山下公園おまつり広場にて。前回は約4万人来場。入場無料。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "GreenSnap Marche YOKOHAMA 2026"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "GreenSnap Marche YOKOHAMA 2026"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>GreenSnap Marche YOKOHAMA 2026</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>GreenSnap Marche YOKOHAMA 2026</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-11" data-date-end="2026-04-12"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月11日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">神奈川</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>日本最大級の植物コミュニティ「GreenSnap」主催。山下公園おまつり広場にて。前回は約4万人来場。入場無料。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B1%B1%E4%B8%8B%E5%85%AC%E5%9C%92%2C%E6%A8%AA%E6%B5%9C%E5%B8%82%E4%B8%AD%E5%8C%BA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%B1%B1%E4%B8%8B%E5%85%AC%E5%9C%92%2C%E6%A8%AA%E6%B5%9C%E5%B8%82%E4%B8%AD%E5%8C%BA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月11日（土） 〜 4月12日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">山下公園 おまつり広場</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=GreenSnap%20Marche%20YOKOHAMA%202026&dates=20260411%2F20260413&location=%E5%B1%B1%E4%B8%8B%E5%85%AC%E5%9C%92%20%E3%81%8A%E3%81%BE%E3%81%A4%E3%82%8A%E5%BA%83%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'greensnap-marche-yokohama-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/hanatomofesta-2026.html
+++ b/events/hanatomofesta-2026.html
@@ -1,293 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/hanatomofesta-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>第8回 花友フェスタ 2026 | アガベイベントナビ</title>
-    <meta name="description" content="花と植物の大型フェスティバル。アガベ、多肉植物から切り花、園芸資材まで、あらゆるニーズに対応。">
-    <meta property="og:title" content="第8回 花友フェスタ 2026">
-    <meta property="og:description" content="花と植物の大型フェスティバル。アガベ、多肉植物から切り花、園芸資材まで、あらゆるニーズに対応。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/hanatomofesta-2026.html">
-    <meta property="og:image" content="https://hanatomofesta.com/files/libs/7138/202602261755302855.png">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; 第8回 花友フェスタ 2026</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://hanatomofesta.com/files/libs/7138/202602261755302855.png" onerror="this.parentElement.style.display='none'" alt="第8回 花友フェスタ 2026" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>第8回 花友フェスタ 2026</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-28">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年4月28日（火）（水・祝）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">千葉県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>第8回花友フェスタは、千葉県の幕張メッセで開催される花と植物の大型フェスティバルです。アガベや多肉植物から切り花、園芸資材まで、花と植物のあらゆるニーズに対応する総合イベント。複数の出展者が様々なジャンルの植物やグリーン関連商品を販売します。</p>
-                    <p>ゴールデンウィーク中の開催とあって、ファミリーからコアな愛好家まで多くの植物ファンが集まります。植物の最新トレンドや栽培技術を学ぶ貴重な機会です。</p>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年4月28日（火）（水・祝）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">幕張メッセ</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">エリア</span>
-                        <span class="info-value">千葉県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://hanatomofesta.com/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC8%E5%9B%9E+%E8%8A%B1%E5%8F%8B%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF+2026&dates=20260428T090000%2F20260428T170000&location=%E5%B9%95%E5%BC%B5%E3%83%A1%E3%83%83%E3%82%BB%2C+%E5%8D%83%E8%91%89%E7%9C%8C&details=%E7%AC%AC8%E5%9B%9E+%E8%8A%B1%E5%8F%8B%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF+2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,マルシェ"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/hanatomofesta-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>第8回 花友フェスタ 2026 | アガベイベントナビ</title>
+  <meta name="description" content="幕張メッセで開催の日本最大級ガーデニングの祭典。園芸超人カーメン君がアンバサダー。前売¥1,600。">
+  <meta name="keywords" content="第8回 花友フェスタ 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="第8回 花友フェスタ 2026 | アガベイベントナビ">
+  <meta property="og:description" content="幕張メッセで開催の日本最大級ガーデニングの祭典。園芸超人カーメン君がアンバサダー。前売¥1,600。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/hanatomofesta-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "第8回 花友フェスタ 2026",
-    "description": "幕張メッセで開催の日本最大級ガーデニングの祭典。園芸超人カーメン君がアンバサダー。前売¥1,600。",
-    "startDate": "2026-04-29T09:00:00+09:00",
-    "endDate": "2026-04-29T17:00:00+09:00",
-    "image": "https://agave-navi.com/images/ogp/hanatomofesta-2026.jpg",
-    "location": {
-        "@type": "Place",
-        "name": "幕張メッセ",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "大阪県"
-        }
-    },
-    "organizer": {
-        "@type": "Organization",
-        "name": "第8回 花友フェスタ 2026",
-        "url": "https://hanatomofesta.com/"
-    },
-    "offers": {
-        "@type": "Offer",
-        "price": "1600",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/hanatomofesta-2026.html"
-    },
+    "startDate": "2026-04-28",
+    "endDate": "2026-04-28",
+    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
-    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode"
-}
-    </script>
+    "location": {
+      "@type": "Place",
+      "name": "幕張メッセ",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "大阪",
+        "addressCountry": "JP"
+      }
+    },
+    "description": "幕張メッセで開催の日本最大級ガーデニングの祭典。園芸超人カーメン君がアンバサダー。前売¥1,600。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "第8回 花友フェスタ 2026"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "第8回 花友フェスタ 2026"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
+    <span>第8回 花友フェスタ 2026</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>第8回 花友フェスタ 2026</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-28" data-date-end=""></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月28日（火）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">大阪</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>幕張メッセで開催の日本最大級ガーデニングの祭典。園芸超人カーメン君がアンバサダー。前売¥1,600。</p>
+        </div>
 
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B9%95%E5%BC%B5%E3%83%A1%E3%83%83%E3%82%BB" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%B9%95%E5%BC%B5%E3%83%A1%E3%83%83%E3%82%BB&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月28日（火）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">幕張メッセ</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">前売¥1,600</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC8%E5%9B%9E%20%E8%8A%B1%E5%8F%8B%E3%83%95%E3%82%A7%E3%82%B9%E3%82%BF%202026&dates=20260428%2F20260429&location=%E5%B9%95%E5%BC%B5%E3%83%A1%E3%83%83%E3%82%BB" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'hanatomofesta-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/hanauchu-dream-garden-26.html
+++ b/events/hanauchu-dream-garden-26.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>第26回 花宇宙ドリームガーデン | アガベイベントナビ</title>
   <meta name="description" content="兵庫県川西市で開催される大型植物イベント。多肉植物やサボテンの専門店が集結。">
-  <meta name="keywords" content="第26回 花宇宙ドリームガーデン,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="第26回 花宇宙ドリームガーデン,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="第26回 花宇宙ドリームガーデン | アガベイベントナビ">
   <meta property="og:description" content="兵庫県川西市で開催される大型植物イベント。多肉植物やサボテンの専門店が集結。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "兵庫",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "兵庫",
+        "addressRegion": "近畿",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月10日（金）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">兵庫</span>
+        <span class="detail-meta-item">近畿</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月10日（金） 〜 4月12日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">近畿</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC26%E5%9B%9E+%E8%8A%B1%E5%AE%87%E5%AE%99%E3%83%89%E3%83%AA%E3%83%BC%E3%83%A0%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3&dates=20260410%2F20260413&location=%E5%85%B5%E5%BA%AB" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC26%E5%9B%9E%20%E8%8A%B1%E5%AE%87%E5%AE%99%E3%83%89%E3%83%AA%E3%83%BC%E3%83%A0%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3&dates=20260410%2F20260413&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'hanauchu-dream-garden-26';

--- a/events/happy-smile-odawara-2026.html
+++ b/events/happy-smile-odawara-2026.html
@@ -1,296 +1,244 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/happy-smile-odawara-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HAPPY SMILE | アガベイベントナビ</title>
-    <meta name="description" content="神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。">
-    <meta property="og:title" content="HAPPY SMILE">
-    <meta property="og:description" content="神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/happy-smile-odawara-2026.html">
-    <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; HAPPY SMILE</div>
-
-    <main class="detail-page">
-        </div>
-        <div class="detail-header">
-            <h1>HAPPY SMILE</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-09-28" data-date-end="2026-09-28">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年9月28日（月）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">神奈川</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=%E5%B0%8F%E7%94%B0%E5%8E%9F%E3%82%A2%E3%83%AA%E3%83%BC%E3%83%8A%2C%E7%A5%9E%E5%A5%88%E5%B7%9D&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年9月28日（月）<br>10:00〜16:00</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">小田原アリーナ</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">開催地域</span>
-                        <span class="info-value">関東</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">Instagram</span>
-                        <span class="info-value"><a href="https://www.instagram.com/happy_smile_plants/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">Instagram →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=HAPPY%20SMILE&dates=20260928T090000%2F20260928T170000&location=%E5%B0%8F%E7%94%B0%E5%8E%9F%E3%82%A2%E3%83%AA%E3%83%BC%E3%83%8A&details=HAPPY%20SMILE+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                <div class="detail-instagram-card">
-                    <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-                    <a href="https://www.instagram.com/happy_smile_plants/" target="_blank" rel="noopener" class="instagram-account-link">
-                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-                        <span class="ig-gradient">@happy_smile_plants</span>
-                    </a>
-                </div>
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/happy-smile-odawara-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HAPPY SMILE | アガベイベントナビ</title>
+  <meta name="description" content="神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。">
+  <meta name="keywords" content="HAPPY SMILE,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="HAPPY SMILE | アガベイベントナビ">
+  <meta property="og:description" content="神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/happy-smile-odawara-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "HAPPY SMILE",
-    "description": "神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。",
-    "startDate": "2026-09-28T10:00:00+09:00",
-    "endDate": "2026-09-28T17:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "小田原アリーナ",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "神奈川"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-09-28",
+    "endDate": "2026-09-28",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": false,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/happy-smile-odawara-2026.html"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "小田原アリーナ",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "神奈川",
+        "addressCountry": "JP"
+      }
+    },
+    "description": "神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "HAPPY SMILE"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "HAPPY SMILE"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>HAPPY SMILE</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>HAPPY SMILE</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-09-28" data-date-end="2026-09-28"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年9月28日（月）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">神奈川</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>神奈川・小田原アリーナで開催される植物の即売イベント。多肉植物やアガベの販売会。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B0%8F%E7%94%B0%E5%8E%9F%E3%82%A2%E3%83%AA%E3%83%BC%E3%83%8A%2C%E7%A5%9E%E5%A5%88%E5%B7%9D" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%B0%8F%E7%94%B0%E5%8E%9F%E3%82%A2%E3%83%AA%E3%83%BC%E3%83%8A%2C%E7%A5%9E%E5%A5%88%E5%B7%9D&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年9月28日（月） 10:00〜16:00</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">小田原アリーナ</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">未定</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">時間</span>
+            <span class="info-value">10:00〜16:00</span>
+          </div>
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=HAPPY%20SMILE&dates=20260928%2F20260929&location=%E5%B0%8F%E7%94%B0%E5%8E%9F%E3%82%A2%E3%83%AA%E3%83%BC%E3%83%8A" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'happy-smile-odawara-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/haru-cactus-succulent-kuro-toyama-2026.html
+++ b/events/haru-cactus-succulent-kuro-toyama-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>春のサボテン・多肉植物展 ―特別展示 黒― | アガベイベントナビ</title>
   <meta name="description" content="富山県中央植物園で開催される春のサボテン・多肉植物展。特別展示「黒」をテーマにした展示即売会。">
-  <meta name="keywords" content="春のサボテン・多肉植物展 ―特別展示 黒―,展示会,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="春のサボテン・多肉植物展 ―特別展示 黒―,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="春のサボテン・多肉植物展 ―特別展示 黒― | アガベイベントナビ">
   <meta property="og:description" content="富山県中央植物園で開催される春のサボテン・多肉植物展。特別展示「黒」をテーマにした展示即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>富山県中央植物園で開催される春のサボテン・多肉植物展。特別展示「黒」をテーマにした展示即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%AF%8C%E5%B1%B1%E7%9C%8C%E4%B8%AD%E5%A4%AE%E6%A4%8D%E7%89%A9%E5%9C%92" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E5%AF%8C%E5%B1%B1%E7%9C%8C%E4%B8%AD%E5%A4%AE%E6%A4%8D%E7%89%A9%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%8C%97%E9%99%B8" class="detail-back-link">北陸のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">北陸</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%98%A5%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E5%B1%95+%E2%80%95%E7%89%B9%E5%88%A5%E5%B1%95%E7%A4%BA+%E9%BB%92%E2%80%95&dates=20260424%2F20260427&location=%E5%AF%8C%E5%B1%B1%E7%9C%8C%E4%B8%AD%E5%A4%AE%E6%A4%8D%E7%89%A9%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%98%A5%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E5%B1%95%20%E2%80%95%E7%89%B9%E5%88%A5%E5%B1%95%E7%A4%BA%20%E9%BB%92%E2%80%95&dates=20260424%2F20260427&location=%E5%AF%8C%E5%B1%B1%E7%9C%8C%E4%B8%AD%E5%A4%AE%E6%A4%8D%E7%89%A9%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'haru-cactus-succulent-kuro-toyama-2026';

--- a/events/haru-saboten-taniku-fair-sapporo-2026.html
+++ b/events/haru-saboten-taniku-fair-sapporo-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -135,12 +135,15 @@
           <p class="instagram-embed-link"><a href="https://www.instagram.com/p/DVxEjm0iWCA/" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
         </div>
 
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E6%9C%AD%E5%B9%8C%E5%B8%82%E5%8C%97%E5%8C%BA%E6%96%B0%E7%90%B4%E4%BC%BC%E7%94%BA787-1-4" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E6%9C%AD%E5%B9%8C%E5%B8%82%E5%8C%97%E5%8C%BA%E6%96%B0%E7%90%B4%E4%BC%BC%E7%94%BA787-1-4&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%8C%97%E6%B5%B7%E9%81%93" class="detail-back-link">北海道のイベントに戻る</a>
@@ -152,8 +155,7 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年4月24日（金） 〜 4月26日（日）
-            9:00〜16:30</span>
+            <span class="info-value">2026年4月24日（金） 〜 4月26日（日） 9:00〜16:30</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
@@ -162,6 +164,11 @@
           <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">北海道</span>
+          </div>
+
+          <div class="info-row">
+            <span class="info-label">時間</span>
+            <span class="info-value">9:00〜16:30</span>
           </div>
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%98%A5%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%95%E3%82%A7%E3%82%A2&dates=20260424%2F20260427&location=%E6%9C%AD%E5%B9%8C%E5%B8%82%E5%8C%97%E5%8C%BA%E6%96%B0%E7%90%B4%E4%BC%BC%E7%94%BA787-1-4" target="_blank" rel="noopener" class="gcal-btn">
@@ -209,7 +216,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'haru-saboten-taniku-fair-sapporo-2026';

--- a/events/haru-saboten-wakayama-2026.html
+++ b/events/haru-saboten-wakayama-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>和歌山で開催される春のサボテン即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%92%8C%E6%AD%8C%E5%B1%B1&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -155,6 +158,8 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">関西</span>
           </div>
+
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%98%A5%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E5%8D%B3%E5%A3%B2%E4%BC%9A&dates=20260504%2F20260506&location=%E5%92%8C%E6%AD%8C%E5%B1%B1" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'haru-saboten-wakayama-2026';

--- a/events/haze-various-genres-marche-2026.html
+++ b/events/haze-various-genres-marche-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>植物を含む多ジャンルのマルシェイベント。アガベ・塊根植物・多肉植物の販売も。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E8%8C%A8%E5%9F%8E%E7%9C%8C%E5%86%85%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E8%8C%A8%E5%9F%8E%E7%9C%8C%E5%86%85%E4%BC%9A%E5%A0%B4&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=HAZE+-various+genres+marche&dates=20260523%2F20260525&location=%E8%8C%A8%E5%9F%8E%E7%9C%8C%E5%86%85%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=HAZE%20-various%20genres%20marche&dates=20260523%2F20260525&location=%E8%8C%A8%E5%9F%8E%E7%9C%8C%E5%86%85%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'haze-various-genres-marche-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/himeji-kisotengai-shokubutsuichi-2026.html
+++ b/events/himeji-kisotengai-shokubutsuichi-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>姫路城で開催される珍奇植物の即売会。アガベ・塊根植物等を販売。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%A7%AB%E8%B7%AF%E5%9F%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -156,7 +159,9 @@
             <span class="info-value">関西</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A7%AB%E8%B7%AF%E5%9F%8E+%E5%A5%87%E8%8D%89%E5%A4%A9%E5%A4%96%E3%81%AA%E6%A4%8D%E7%89%A9%E5%B8%82&dates=20260607%2F20260608&location=%E5%A7%AB%E8%B7%AF%E5%9F%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A7%AB%E8%B7%AF%E5%9F%8E%20%E5%A5%87%E8%8D%89%E5%A4%A9%E5%A4%96%E3%81%AA%E6%A4%8D%E7%89%A9%E5%B8%82&dates=20260607%2F20260608&location=%E5%A7%AB%E8%B7%AF%E5%9F%8E" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'himeji-kisotengai-shokubutsuichi-2026';

--- a/events/hobby-plants-freaks-vol5.html
+++ b/events/hobby-plants-freaks-vol5.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/hobby-plants-freaks-vol5.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hobby Plants Freaks Vol5 | アガベイベントナビ</title>
-    <meta name="description" content="岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。">
-    <meta property="og:title" content="Hobby Plants Freaks Vol5">
-    <meta property="og:description" content="岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/hobby-plants-freaks-vol5.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt; Hobby Plants Freaks Vol5</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>Hobby Plants Freaks Vol5</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-25">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月25日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">岡山県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>Hobby Plants Freaks Vol5は岡山県で開催される植物イベントです。岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=岡山%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年04月25日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">岡山県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Hobby Plants Freaks Vol5&dates=20260425%2F20260427&location=岡山&details=Hobby Plants Freaks Vol5+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/hobby-plants-freaks-vol5.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hobby Plants Freaks Vol5 | アガベイベントナビ</title>
+  <meta name="description" content="岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。">
+  <meta name="keywords" content="Hobby Plants Freaks Vol5,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="Hobby Plants Freaks Vol5 | アガベイベントナビ">
+  <meta property="og:description" content="岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/hobby-plants-freaks-vol5.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "Hobby Plants Freaks Vol5",
-    "description": "岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。",
     "startDate": "2026-04-25",
-    "location": {
-        "@type": "Place",
-        "name": "ナガサコファーム",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "岡山県",
-            "addressLocality": "ナガサコファーム"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-04-26",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "Hobby Plants Freaks Vol5"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "岡山県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "岡山",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/hobby-plants-freaks-vol5.html"
+    "description": "岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "Hobby Plants Freaks Vol5"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "中国のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E5%9B%BD"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "Hobby Plants Freaks Vol5"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E4%B8%AD%E5%9B%BD">中国のイベント</a> &gt;
+    <span>Hobby Plants Freaks Vol5</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>Hobby Plants Freaks Vol5</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-25" data-date-end="2026-04-26"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月25日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">岡山</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>岡山県笠岡市で開催されるホビープランツのイベント。レアな植物が集まる。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B2%A1%E5%B1%B1%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%B2%A1%E5%B1%B1%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月25日（土） 〜 4月26日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">岡山県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">中国</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Hobby%20Plants%20Freaks%20Vol5&dates=20260425%2F20260427&location=%E5%B2%A1%E5%B1%B1%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'hobby-plants-freaks-vol5';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/hosokawa-botafes-2026-spring.html
+++ b/events/hosokawa-botafes-2026-spring.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HOSOKAWA BOTAFES '26 spring | アガベイベントナビ</title>
   <meta name="description" content="大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。">
-  <meta name="keywords" content="HOSOKAWA BOTAFES '26 spring,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="HOSOKAWA BOTAFES '26 spring,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="HOSOKAWA BOTAFES '26 spring | アガベイベントナビ">
   <meta property="og:description" content="大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>大阪府池田市細河地区の旧細河小学校で開催される春のボタニカルフェスティバル。植木職人による装飾と植物文化を主軸に、多肉植物・植木・マーケット出店などを楽しめる2日間のイベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E6%97%A7%E7%B4%B0%E6%B2%B3%E5%B0%8F%E5%AD%A6%E6%A0%A1" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E6%97%A7%E7%B4%B0%E6%B2%B3%E5%B0%8F%E5%AD%A6%E6%A0%A1&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関西</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=HOSOKAWA+BOTAFES+%2726+spring&dates=20260523%2F20260525&location=%E6%97%A7%E7%B4%B0%E6%B2%B3%E5%B0%8F%E5%AD%A6%E6%A0%A1" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=HOSOKAWA%20BOTAFES%20%2726%20spring&dates=20260523%2F20260525&location=%E6%97%A7%E7%B4%B0%E6%B2%B3%E5%B0%8F%E5%AD%A6%E6%A0%A1" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'hosokawa-botafes-2026-spring';

--- a/events/ibaraki-sky-palette-2026.html
+++ b/events/ibaraki-sky-palette-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>いばらきスカイパレット 植物マルシェ | アガベイベントナビ</title>
   <meta name="description" content="茨城県の屋外施設で開催された植物マーケット。">
-  <meta name="keywords" content="いばらきスカイパレット 植物マルシェ,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="いばらきスカイパレット 植物マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="いばらきスカイパレット 植物マルシェ | アガベイベントナビ">
   <meta property="og:description" content="茨城県の屋外施設で開催された植物マーケット。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,7 +35,7 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "茨城",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
         "addressRegion": "茨城",
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,22 +144,22 @@
             <span class="info-value">2026年2月21日（土）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%81%84%E3%81%B0%E3%82%89%E3%81%8D%E3%82%B9%E3%82%AB%E3%82%A4%E3%83%91%E3%83%AC%E3%83%83%E3%83%88+%E6%A4%8D%E7%89%A9%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260221%2F20260222&location=%E8%8C%A8%E5%9F%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%81%84%E3%81%B0%E3%82%89%E3%81%8D%E3%82%B9%E3%82%AB%E3%82%A4%E3%83%91%E3%83%AC%E3%83%83%E3%83%88%20%E6%A4%8D%E7%89%A9%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260221%2F20260222&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/sky_palette_ibaraki/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@sky_palette_ibaraki</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -197,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'ibaraki-sky-palette-2026';

--- a/events/iku-matsuri-ichinomiya-spring.html
+++ b/events/iku-matsuri-ichinomiya-spring.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>樹祭 in 一宮 2026春 | アガベイベントナビ</title>
   <meta name="description" content="愛知県一宮市で開催される植物即売イベント。アガベ・塊根植物・観葉植物のショップが多数出店する大型即売会です。">
-  <meta name="keywords" content="樹祭 in 一宮 2026春,即売会,大型,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="樹祭 in 一宮 2026春,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="樹祭 in 一宮 2026春 | アガベイベントナビ">
   <meta property="og:description" content="愛知県一宮市で開催される植物即売イベント。アガベ・塊根植物・観葉植物のショップが多数出店する大型即売会です。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "愛知",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "愛知",
+        "addressRegion": "中部",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月11日（土）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">愛知</span>
+        <span class="detail-meta-item">中部</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月11日（土） 〜 4月12日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">中部</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%B9%E7%A5%AD+in+%E4%B8%80%E5%AE%AE+2026%E6%98%A5&dates=20260411%2F20260413&location=%E6%84%9B%E7%9F%A5" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%B9%E7%A5%AD%20in%20%E4%B8%80%E5%AE%AE%202026%E6%98%A5&dates=20260411%2F20260413&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'iku-matsuri-ichinomiya-spring';

--- a/events/iku-matsuri-utsunomiya-2026.html
+++ b/events/iku-matsuri-utsunomiya-2026.html
@@ -1,294 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/iku-matsuri-utsunomiya-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>樹祭 in 宇都宮 2026 | アガベイベントナビ</title>
-    <meta name="description" content="栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会。">
-    <meta property="og:title" content="樹祭 in 宇都宮 2026">
-    <meta property="og:description" content="栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/iku-matsuri-utsunomiya-2026.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; 樹祭 in 宇都宮 2026</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>樹祭 in 宇都宮 2026</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-30" data-date-end="2026-05-31">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月30日（土）-31日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">栃木県宇都宮市</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>栃木県宇都宮市で開催される樹祭は、関東地区における重要な大型植物即売会です。アガベ・塊根植物・観葉植物を扱う多数のショップが出店し、2日間にわたり充実した品揃えが期待できます。</p>
-                    <p>本イベントは植物愛好家のための買い物の場として、毎回多くの来場者を集めています。珍しい品種から定番の植物まで、幅広い選択肢が提供される充実の内容になっています。宇都宮という立地により、関東各地からアクセスも良好です。</p>
-                    <p>春から初夏への季節の転わり目に開催される本イベントは、新しい植物シーズンを迎える愛好家にとって最適なタイミングです。2日間のイベントをじっくり楽しみましょう。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=%E5%AE%87%E9%83%BD%E5%AE%AE%E5%B8%82&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年5月30日（土）-31日（日）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">宇都宮市</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%B9%E7%A5%AD+in+%E5%AE%87%E9%83%BD%E5%AE%AE+2026&dates=20260530%2F20260601&location=%E6%A0%83%E6%9C%A8%E7%9C%8C%E5%AE%87%E9%83%BD%E5%AE%AE%E5%B8%82&details=%E6%A8%B9%E7%A5%AD+in+%E5%AE%87%E9%83%BD%E5%AE%AE+2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                <div class="detail-instagram-card">
-                    <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-                    <a href="https://www.instagram.com/iku_matsuri/" target="_blank" rel="noopener" class="instagram-account-link">
-                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-                        <span class="ig-gradient">@iku_matsuri</span>
-                    </a>
-                </div>
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会,大型"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/iku-matsuri-utsunomiya-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>樹祭 in 宇都宮 2026 | アガベイベントナビ</title>
+  <meta name="description" content="栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会です。">
+  <meta name="keywords" content="樹祭 in 宇都宮 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="樹祭 in 宇都宮 2026 | アガベイベントナビ">
+  <meta property="og:description" content="栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会です。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/iku-matsuri-utsunomiya-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "樹祭 in 宇都宮 2026",
-    "description": "栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会。",
     "startDate": "2026-05-30",
     "endDate": "2026-05-31",
-    "location": {
-        "@type": "Place",
-        "name": "宇都宮市",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "栃木県",
-            "addressLocality": "宇都宮市"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/iku-matsuri-utsunomiya-2026.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "樹祭 in 宇都宮 2026",
-        "url": "https://www.instagram.com/iku_matsuri/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "宇都宮市",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "栃木",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/iku-matsuri-utsunomiya-2026.html"
+    "description": "栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会です。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "樹祭 in 宇都宮 2026"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "樹祭 in 宇都宮 2026"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>樹祭 in 宇都宮 2026</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>樹祭 in 宇都宮 2026</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-30" data-date-end="2026-05-31"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月30日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">栃木</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>栃木県宇都宮市で開催される樹祭。アガベ・塊根植物・観葉植物のショップが出店する大型即売会です。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%AE%87%E9%83%BD%E5%AE%AE%E5%B8%82" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%AE%87%E9%83%BD%E5%AE%AE%E5%B8%82&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月30日（土） 〜 5月31日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">宇都宮市</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%B9%E7%A5%AD%20in%20%E5%AE%87%E9%83%BD%E5%AE%AE%202026&dates=20260530%2F20260601&location=%E5%AE%87%E9%83%BD%E5%AE%AE%E5%B8%82" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'iku-matsuri-utsunomiya-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/isij-big-bazaar-2026-05-24.html
+++ b/events/isij-big-bazaar-2026-05-24.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>5月のサボテン・多肉植物ビッグバザール | アガベイベントナビ</title>
   <meta name="description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。">
-  <meta name="keywords" content="5月のサボテン・多肉植物ビッグバザール,大型,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="5月のサボテン・多肉植物ビッグバザール,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="5月のサボテン・多肉植物ビッグバザール | アガベイベントナビ">
   <meta property="og:description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階にて9:45開場予定。アガベ・コーデックスも多数出店。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=5%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260524%2F20260525&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB+13%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=5%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260524%2F20260525&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'isij-big-bazaar-2026-05-24';

--- a/events/isij-big-bazaar-2026-07-12.html
+++ b/events/isij-big-bazaar-2026-07-12.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>7月のサボテン・多肉植物ビッグバザール | アガベイベントナビ</title>
   <meta name="description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。">
-  <meta name="keywords" content="7月のサボテン・多肉植物ビッグバザール,大型,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="7月のサボテン・多肉植物ビッグバザール,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="7月のサボテン・多肉植物ビッグバザール | アガベイベントナビ">
   <meta property="og:description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される夏の定例即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=7%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260712%2F20260713&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB+13%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=7%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260712%2F20260713&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'isij-big-bazaar-2026-07-12';

--- a/events/isij-big-bazaar-2026-09-27.html
+++ b/events/isij-big-bazaar-2026-09-27.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>9月のサボテン・多肉植物ビッグバザール | アガベイベントナビ</title>
   <meta name="description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。">
-  <meta name="keywords" content="9月のサボテン・多肉植物ビッグバザール,大型,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="9月のサボテン・多肉植物ビッグバザール,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="9月のサボテン・多肉植物ビッグバザール | アガベイベントナビ">
   <meta property="og:description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される秋の定例即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=9%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260927%2F20260928&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB+13%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=9%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20260927%2F20260928&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'isij-big-bazaar-2026-09-27';

--- a/events/isij-big-bazaar-2026-11-22.html
+++ b/events/isij-big-bazaar-2026-11-22.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>11月のサボテン・多肉植物ビッグバザール | アガベイベントナビ</title>
   <meta name="description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。">
-  <meta name="keywords" content="11月のサボテン・多肉植物ビッグバザール,大型,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="11月のサボテン・多肉植物ビッグバザール,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="11月のサボテン・多肉植物ビッグバザール | アガベイベントナビ">
   <meta property="og:description" content="ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>ISIJ（国際多肉植物協会）主催のサボテン・多肉植物ビッグバザール。五反田TOCビル13階で開催される年内最後の定例即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=11%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20261122%2F20261123&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB+13%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=11%E6%9C%88%E3%81%AE%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%83%BB%E5%A4%9A%E8%82%89%E6%A4%8D%E7%89%A9%E3%83%93%E3%83%83%E3%82%B0%E3%83%90%E3%82%B6%E3%83%BC%E3%83%AB&dates=20261122%2F20261123&location=%E4%BA%94%E5%8F%8D%E7%94%B0TOC%E3%83%93%E3%83%AB%2013%E9%9A%8E" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'isij-big-bazaar-2026-11-22';

--- a/events/iwate-hana-midori-matsuri-2026.html
+++ b/events/iwate-hana-midori-matsuri-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>花と緑のまつり | アガベイベントナビ</title>
   <meta name="description" content="岩手で開催される花と緑の祭り。植物販売会。">
-  <meta name="keywords" content="花と緑のまつり,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="花と緑のまつり,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="花と緑のまつり | アガベイベントナビ">
   <meta property="og:description" content="岩手で開催される花と緑の祭り。植物販売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>岩手で開催される花と緑の祭り。植物販売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%B2%A9%E6%89%8B&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
@@ -155,6 +158,8 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">東北</span>
           </div>
+
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E8%8A%B1%E3%81%A8%E7%B7%91%E3%81%AE%E3%81%BE%E3%81%A4%E3%82%8A&dates=20260605%2F20260608&location=%E5%B2%A9%E6%89%8B" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'iwate-hana-midori-matsuri-2026';

--- a/events/jiyugaoka-botanical-market-2026.html
+++ b/events/jiyugaoka-botanical-market-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Jiyugaoka Botanical Market | アガベイベントナビ</title>
   <meta name="description" content="自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。">
-  <meta name="keywords" content="Jiyugaoka Botanical Market,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="Jiyugaoka Botanical Market,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="Jiyugaoka Botanical Market | アガベイベントナビ">
   <meta property="og:description" content="自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>自由が丘で開催されるボタニカルマーケット。多肉植物や観葉植物の販売イベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E8%87%AA%E7%94%B1%E3%81%8C%E4%B8%98&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -156,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Jiyugaoka+Botanical+Market&dates=20260504%2F20260506&location=%E8%87%AA%E7%94%B1%E3%81%8C%E4%B8%98" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Jiyugaoka%20Botanical%20Market&dates=20260504%2F20260506&location=%E8%87%AA%E7%94%B1%E3%81%8C%E4%B8%98" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'jiyugaoka-botanical-market-2026';

--- a/events/joyful-festival-2026.html
+++ b/events/joyful-festival-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "JOYFUL FESTIVAL"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>ジョイフル本田千葉ニュータウン店で開催される植物の即売イベント。多肉植物や観葉植物が集まります。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E3%82%B8%E3%83%A7%E3%82%A4%E3%83%95%E3%83%AB%E6%9C%AC%E7%94%B0%20%E5%8D%83%E8%91%89%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%BF%E3%82%A6%E3%83%B3%E5%BA%97&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -152,34 +148,31 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年4月4日（土） 〜 4月5日（日）
-            10:00〜17:00</span>
+            <span class="info-value">2026年4月4日（土） 〜 4月5日（日） 10:00〜17:00</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">ジョイフル本田 千葉ニュータウン店</span>
           </div>
           <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">無料</span>
           </div>
           <div class="info-row">
-            <span class="info-label">開催地域</span>
-            <span class="info-value">関東</span>
+            <span class="info-label">時間</span>
+            <span class="info-value">10:00〜17:00</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=JOYFUL+FESTIVAL&dates=20260404%2F20260406&location=%E3%82%B8%E3%83%A7%E3%82%A4%E3%83%95%E3%83%AB%E6%9C%AC%E7%94%B0+%E5%8D%83%E8%91%89%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%BF%E3%82%A6%E3%83%B3%E5%BA%97" target="_blank" rel="noopener" class="gcal-btn">
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=JOYFUL%20FESTIVAL&dates=20260404%2F20260406&location=%E3%82%B8%E3%83%A7%E3%82%A4%E3%83%95%E3%83%AB%E6%9C%AC%E7%94%B0%20%E5%8D%83%E8%91%89%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%BF%E3%82%A6%E3%83%B3%E5%BA%97" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/joyfulhonda_official/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@joyfulhonda_official</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -219,7 +212,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'joyful-festival-2026';

--- a/events/jungle-plants-market.html
+++ b/events/jungle-plants-market.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>JUNGLE PLANTS MARKET | アガベイベントナビ</title>
   <meta name="description" content="埼玉県久喜市で開催されるジャングルプランツのマルシェ。アロイドやジャングルプランツが揃う。">
-  <meta name="keywords" content="JUNGLE PLANTS MARKET,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="JUNGLE PLANTS MARKET,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="JUNGLE PLANTS MARKET | アガベイベントナビ">
   <meta property="og:description" content="埼玉県久喜市で開催されるジャングルプランツのマルシェ。アロイドやジャングルプランツが揃う。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "埼玉",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "埼玉",
+        "addressRegion": "関東",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月12日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">埼玉</span>
+        <span class="detail-meta-item">関東</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月12日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=JUNGLE+PLANTS+MARKET&dates=20260412%2F20260413&location=%E5%9F%BC%E7%8E%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=JUNGLE%20PLANTS%20MARKET&dates=20260412%2F20260413&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'jungle-plants-market';

--- a/events/kisarazu-cs-fair.html
+++ b/events/kisarazu-cs-fair.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/kisarazu-cs-fair.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>KISARAZU C&S FAIR | アガベイベントナビ</title>
-    <meta name="description" content="千葉県木更津市で開催されるカクタス&サボテンのフェア。サボテン愛好家が集結。">
-    <meta property="og:title" content="KISARAZU C&S FAIR">
-    <meta property="og:description" content="千葉県木更津市で開催されるカクタス&サボテンのフェア。サボテン愛好家が集結。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/kisarazu-cs-fair.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; KISARAZU C&S FAIR</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>KISARAZU C&S FAIR</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-26">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月26日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">千葉県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>KISARAZU C&S FAIRは千葉県で開催される植物イベントです。千葉県木更津市で開催されるカクタス&サボテンのフェア。サボテン愛好家が集結。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=千葉%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年04月26日（日）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">千葉県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=KISARAZU C&S FAIR&dates=20260426%2F20260427&location=千葉&details=KISARAZU C&S FAIR+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/kisarazu-cs-fair.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KISARAZU C&amp;S FAIR | アガベイベントナビ</title>
+  <meta name="description" content="千葉県木更津市で開催されるカクタス&amp;サボテンのフェア。サボテン愛好家が集結。">
+  <meta name="keywords" content="KISARAZU C&amp;S FAIR,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="KISARAZU C&amp;S FAIR | アガベイベントナビ">
+  <meta property="og:description" content="千葉県木更津市で開催されるカクタス&amp;サボテンのフェア。サボテン愛好家が集結。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/kisarazu-cs-fair.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": "KISARAZU C&S FAIR",
-    "description": "千葉県木更津市で開催されるカクタス&サボテンのフェア。サボテン愛好家が集結。",
+    "name": "KISARAZU C&amp;S FAIR",
     "startDate": "2026-04-26",
-    "location": {
-        "@type": "Place",
-        "name": "スパークルシティ木更津",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "千葉県",
-            "addressLocality": "スパークルシティ木更津"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-04-26",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "KISARAZU C&S FAIR"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "千葉県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "千葉",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/kisarazu-cs-fair.html"
+    "description": "千葉県木更津市で開催されるカクタス&amp;サボテンのフェア。サボテン愛好家が集結。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "KISARAZU C&amp;S FAIR"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "KISARAZU C&amp;S FAIR"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>KISARAZU C&amp;S FAIR</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>KISARAZU C&amp;S FAIR</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-26" data-date-end="2026-04-26"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月26日（日）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">千葉</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>千葉県木更津市で開催されるカクタス&amp;サボテンのフェア。サボテン愛好家が集結。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%8D%83%E8%91%89%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%8D%83%E8%91%89%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月26日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">千葉県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=KISARAZU%20C%26S%20FAIR&dates=20260426%2F20260427&location=%E5%8D%83%E8%91%89%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'kisarazu-cs-fair';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/kumagaya-taniku-fes-2026.html
+++ b/events/kumagaya-taniku-fes-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,7 +35,7 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "埼玉",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
         "addressRegion": "埼玉",
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,22 +144,22 @@
             <span class="info-value">2026年2月14日（土） 〜 2月15日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC2%E5%9B%9E+%E7%86%8A%E8%B0%B7%E5%A4%9A%E8%82%89%E3%83%95%E3%82%A7%E3%82%B9&dates=20260214%2F20260216&location=%E5%9F%BC%E7%8E%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC2%E5%9B%9E%20%E7%86%8A%E8%B0%B7%E5%A4%9A%E8%82%89%E3%83%95%E3%82%A7%E3%82%B9&dates=20260214%2F20260216&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/kumagaya_taniku_fes/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@kumagaya_taniku_fes</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -197,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'kumagaya-taniku-fes-2026';

--- a/events/mini-soransai-june-2026.html
+++ b/events/mini-soransai-june-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>埼玉県越谷市のシマムラ園芸で開催されるアガベ・多肉植物の即売会。入場無料。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%20%E7%AC%AC2%E3%83%8F%E3%82%A6%E3%82%B9" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%20%E7%AC%AC2%E3%83%8F%E3%82%A6%E3%82%B9&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9F%E3%83%8B%E8%8D%89%E4%B9%B1%E7%A5%AD%EF%BC%886%E6%9C%88%EF%BC%89&dates=20260620%2F20260622&location=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8+%E7%AC%AC2%E3%83%8F%E3%82%A6%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9F%E3%83%8B%E8%8D%89%E4%B9%B1%E7%A5%AD%EF%BC%886%E6%9C%88%EF%BC%89&dates=20260620%2F20260622&location=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%20%E7%AC%AC2%E3%83%8F%E3%82%A6%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'mini-soransai-june-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/miyashita-park-popup-2026.html
+++ b/events/miyashita-park-popup-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>渋谷の大型商業施設での期間限定ポップアップストア。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=MIYASHITA%20PARK&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -156,18 +159,14 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=MIYASHITA+PARK+Pop-Up+Store&dates=20260218%2F20260302&location=MIYASHITA+PARK" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=MIYASHITA%20PARK%20Pop-Up%20Store&dates=20260218%2F20260302&location=MIYASHITA%20PARK" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/miyashita_park_popup/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@miyashita_park_popup</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -207,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'miyashita-park-popup-2026';

--- a/events/monster-plants-2026.html
+++ b/events/monster-plants-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>モンスタープランツ 2026 | アガベイベントナビ</title>
   <meta name="description" content="希少な植物種が集まる大規模展示会。全国から愛好家が集結するイベントです。">
-  <meta name="keywords" content="モンスタープランツ 2026,大型,展示会,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="モンスタープランツ 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="モンスタープランツ 2026 | アガベイベントナビ">
   <meta property="og:description" content="希少な植物種が集まる大規模展示会。全国から愛好家が集結するイベントです。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "東京",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "東京",
+        "addressRegion": "関東",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月20日（月）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">東京</span>
+        <span class="detail-meta-item">関東</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月20日（月）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84+2026&dates=20260420%2F20260421&location=%E6%9D%B1%E4%BA%AC" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84%202026&dates=20260420%2F20260421&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'monster-plants-2026';
@@ -219,6 +227,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/monster-plants-2nd-marugame-2026.html
+++ b/events/monster-plants-2nd-marugame-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>モンスタープランツ 第2弾 | アガベイベントナビ</title>
   <meta name="description" content="香川県丸亀市で開催される珍奇植物販売会。入場無料。">
-  <meta name="keywords" content="モンスタープランツ 第2弾,即売会,珍奇植物,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="モンスタープランツ 第2弾,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="モンスタープランツ 第2弾 | アガベイベントナビ">
   <meta property="og:description" content="香川県丸亀市で開催される珍奇植物販売会。入場無料。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>香川県丸亀市で開催される珍奇植物販売会。入場無料。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E7%B6%BE%E6%AD%8C%E7%B7%8F%E5%90%88%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8%E3%82%A2%E3%82%A4%E3%83%AC%E3%83%83%E3%82%AF%E3%82%B9" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E7%B6%BE%E6%AD%8C%E7%B7%8F%E5%90%88%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8%E3%82%A2%E3%82%A4%E3%83%AC%E3%83%83%E3%82%AF%E3%82%B9&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">四国</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84+%E7%AC%AC2%E5%BC%BE&dates=20260412%2F20260413&location=%E7%B6%BE%E6%AD%8C%E7%B7%8F%E5%90%88%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8%E3%82%A2%E3%82%A4%E3%83%AC%E3%83%83%E3%82%AF%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%A2%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%BC%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84%20%E7%AC%AC2%E5%BC%BE&dates=20260412%2F20260413&location=%E7%B6%BE%E6%AD%8C%E7%B7%8F%E5%90%88%E6%96%87%E5%8C%96%E4%BC%9A%E9%A4%A8%E3%82%A2%E3%82%A4%E3%83%AC%E3%83%83%E3%82%AF%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'monster-plants-2nd-marugame-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/must-buy-market-okinawa-2026.html
+++ b/events/must-buy-market-okinawa-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MUST BUY MARKET! | アガベイベントナビ</title>
   <meta name="description" content="沖縄で開催される植物販売マーケット。">
-  <meta name="keywords" content="MUST BUY MARKET!,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="MUST BUY MARKET!,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="MUST BUY MARKET! | アガベイベントナビ">
   <meta property="og:description" content="沖縄で開催される植物販売マーケット。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>沖縄で開催される植物販売マーケット。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E6%B2%96%E7%B8%84&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
@@ -156,7 +159,9 @@
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=MUST+BUY+MARKET%21&dates=20260509%2F20260511&location=%E6%B2%96%E7%B8%84" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=MUST%20BUY%20MARKET%21&dates=20260509%2F20260511&location=%E6%B2%96%E7%B8%84" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'must-buy-market-okinawa-2026';

--- a/events/myoko-taniku-market-13th-2026.html
+++ b/events/myoko-taniku-market-13th-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>新潟県妙高市・道の駅あらいで毎月開催される多肉植物の即売会第13回。県内外の栽培家や園芸愛好家による多肉植物・雑貨販売とキッチンカーが集結。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%82%E3%82%89%E3%81%84%20%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E5%A6%99%E9%AB%98" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%82%E3%82%89%E3%81%84%20%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E5%A6%99%E9%AB%98&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%8C%97%E9%99%B8" class="detail-back-link">北陸のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">北陸</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A6%99%E9%AB%98%E5%A4%9A%E8%82%89%E5%B8%82%E5%A0%B4+13th&dates=20260524%2F20260525&location=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%82%E3%82%89%E3%81%84+%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E5%A6%99%E9%AB%98" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A6%99%E9%AB%98%E5%A4%9A%E8%82%89%E5%B8%82%E5%A0%B4%2013th&dates=20260524%2F20260525&location=%E9%81%93%E3%81%AE%E9%A7%85%E3%81%82%E3%82%89%E3%81%84%20%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E5%A6%99%E9%AB%98" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'myoko-taniku-market-13th-2026';

--- a/events/nara-botanical-garden-2026.html
+++ b/events/nara-botanical-garden-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ならの植物園2026 | アガベイベントナビ</title>
   <meta name="description" content="奈良県田原本町で開催される植物の展示即売イベント。アガベや多肉植物を扱う出店者が集まります。">
-  <meta name="keywords" content="ならの植物園2026,即売会,展示会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="ならの植物園2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="ならの植物園2026 | アガベイベントナビ">
   <meta property="og:description" content="奈良県田原本町で開催される植物の展示即売イベント。アガベや多肉植物を扱う出店者が集まります。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "ならの植物園2026"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>奈良県田原本町で開催される植物の展示即売イベント。アガベや多肉植物を扱う出店者が集まります。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E7%A3%AF%E5%9F%8E%E9%83%A1%E7%94%B0%E5%8E%9F%E6%9C%AC%E7%94%BA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -159,26 +155,21 @@
             <span class="info-value">磯城郡田原本町</span>
           </div>
           <div class="info-row">
-            <span class="info-label">入場料</span>
-            <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関西</span>
           </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%81%AA%E3%82%89%E3%81%AE%E6%A4%8D%E7%89%A9%E5%9C%922026&dates=20260328%2F20260330&location=%E7%A3%AF%E5%9F%8E%E9%83%A1%E7%94%B0%E5%8E%9F%E6%9C%AC%E7%94%BA" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/nara.botanical_garden/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@nara.botanical_garden</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -218,7 +209,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'nara-botanical-garden-2026';

--- a/events/okibota-spring-2026-sunshine.html
+++ b/events/okibota-spring-2026-sunshine.html
@@ -1,293 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/okibota-spring-2026-sunshine.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>オキボタ Spring 2026 in サンシャインシティー | アガベイベントナビ</title>
-    <meta name="description" content="2026年4月10日〜12日、池袋サンシャインシティ展示ホールAで開催。国内外の植物を扱う70店舗以上が参加する大型植物即売会。初日先行入場1,000円、一般500円、最終日無料。主催：合同会社OKIBOTA。">
-    <meta property="og:title" content="オキボタ Spring 2026 in サンシャインシティー">
-    <meta property="og:description" content="2026年4月10日〜12日、池袋サンシャインシティ展示ホールAで開催。国内外の植物を扱う70店舗以上が参加する大型植物即売会。">
-    <meta property="og:image" content="https://sunshinecity.jp/archives/001/202603/1f24737a056714394aad6df81c43215e883e3d262f85d7610e941dc5e1eae825.jpg">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/okibota-spring-2026-sunshine.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; オキボタ Spring 2026 in サンシャインシティー</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>オキボタ Spring 2026 in サンシャインシティー</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-10">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月10日（金）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">東京都</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>国内外の植物を扱う70店舗以上が参加する大型植物即売会です。4月は花の咲く種類が多いシーズンで、珍しい品種を含む多様な植物が会場に集結します。</p>
-                    <p>初日（4月10日）は9:00から先行入場（1,000円）が可能で、一般入場は10:00から500円です。最終日（4月12日）は15:00まで・入場無料となります。</p>
-                    <p>主催は合同会社OKIBOTAで、お問い合わせは080-8043-6851（10時〜16時）まで。公式情報は<a href="https://sunshinecity.jp/event/entry-36647.html" target="_blank" rel="noopener">サンシャインシティ公式サイト</a>をご確認ください。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=%E3%82%B5%E3%83%B3%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%86%E3%82%A3+%E5%B1%95%E7%A4%BA%E3%83%9B%E3%83%BC%E3%83%ABA&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年4月10日（金）〜12日（日）<br>10:00〜18:00（最終日15:00まで）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">サンシャインシティ 展示ホールA<br>（東京都豊島区東池袋3-1）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">先行入場（初日9:00〜）1,000円<br>一般入場 500円<br>最終日 無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">主催</span>
-                        <span class="info-value">合同会社OKIBOTA</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=オキボタ Spring 2026 in サンシャインシティー&dates=20260410%2F20260413&location=東京&details=オキボタ Spring 2026 in サンシャインシティー+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/okibota-spring-2026-sunshine.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>オキボタ Spring 2026 in サンシャインシティー | アガベイベントナビ</title>
+  <meta name="description" content="東京・池袋のサンシャインシティで開催される植物即売会。多様な植物が揃うイベント。">
+  <meta name="keywords" content="オキボタ Spring 2026 in サンシャインシティー,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="オキボタ Spring 2026 in サンシャインシティー | アガベイベントナビ">
+  <meta property="og:description" content="東京・池袋のサンシャインシティで開催される植物即売会。多様な植物が揃うイベント。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/okibota-spring-2026-sunshine.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "オキボタ Spring 2026 in サンシャインシティー",
-    "description": "国内外の植物を扱う70店舗以上が参加する大型植物即売会。2026年4月10日〜12日、池袋サンシャインシティ展示ホールAで開催。",
     "startDate": "2026-04-10",
     "endDate": "2026-04-12",
-    "location": {
-        "@type": "Place",
-        "name": "サンシャインシティ 展示ホールA",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "東京都",
-            "addressLocality": "豊島区東池袋3-1",
-            "postalCode": "170-8630"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": false,
-    "image": "https://sunshinecity.jp/archives/001/202603/1f24737a056714394aad6df81c43215e883e3d262f85d7610e941dc5e1eae825.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "合同会社OKIBOTA"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "サンシャインシティ 展示ホールA&lt;br&gt;（東京都豊島区東池袋3-1）",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "東京",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "500",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://sunshinecity.jp/event/entry-36647.html"
+    "description": "東京・池袋のサンシャインシティで開催される植物即売会。多様な植物が揃うイベント。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "オキボタ Spring 2026 in サンシャインシティー"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "オキボタ Spring 2026 in サンシャインシティー"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>オキボタ Spring 2026 in サンシャインシティー</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>オキボタ Spring 2026 in サンシャインシティー</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-10" data-date-end="2026-04-12"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月10日（金）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">東京</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>東京・池袋のサンシャインシティで開催される植物即売会。多様な植物が揃うイベント。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%82%B5%E3%83%B3%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%86%E3%82%A3%2B%E5%B1%95%E7%A4%BA%E3%83%9B%E3%83%BC%E3%83%ABA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E3%82%B5%E3%83%B3%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%86%E3%82%A3%2B%E5%B1%95%E7%A4%BA%E3%83%9B%E3%83%BC%E3%83%ABA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月10日（金） 〜 4月12日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">サンシャインシティ 展示ホールA&lt;br&gt;（東京都豊島区東池袋3-1）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%82%AA%E3%82%AD%E3%83%9C%E3%82%BF%20Spring%202026%20in%20%E3%82%B5%E3%83%B3%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%86%E3%82%A3%E3%83%BC&dates=20260410%2F20260413&location=%E3%82%B5%E3%83%B3%E3%82%B7%E3%83%A3%E3%82%A4%E3%83%B3%E3%82%B7%E3%83%86%E3%82%A3%20%E5%B1%95%E7%A4%BA%E3%83%9B%E3%83%BC%E3%83%ABA%3Cbr%3E%EF%BC%88%E6%9D%B1%E4%BA%AC%E9%83%BD%E8%B1%8A%E5%B3%B6%E5%8C%BA%E6%9D%B1%E6%B1%A0%E8%A2%8B3-1%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'okibota-spring-2026-sunshine';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/our-plants-2-03.html
+++ b/events/our-plants-2-03.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/our-plants-2-03.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Our Plants ver.2.03 | アガベイベントナビ</title>
-    <meta name="description" content="京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。">
-    <meta property="og:title" content="Our Plants ver.2.03">
-    <meta property="og:description" content="京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/our-plants-2-03.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt; Our Plants ver.2.03</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>Our Plants ver.2.03</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-25">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月25日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">京都県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>Our Plants ver.2.03は京都県で開催される植物イベントです。京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=京都%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年04月25日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">京都県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Our Plants ver.2.03&dates=20260425%2F20260426&location=京都&details=Our Plants ver.2.03+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/our-plants-2-03.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Our Plants ver.2.03 | アガベイベントナビ</title>
+  <meta name="description" content="京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。">
+  <meta name="keywords" content="Our Plants ver.2.03,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="Our Plants ver.2.03 | アガベイベントナビ">
+  <meta property="og:description" content="京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/our-plants-2-03.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "Our Plants ver.2.03",
-    "description": "京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。",
     "startDate": "2026-04-25",
-    "location": {
-        "@type": "Place",
-        "name": "梅小路公園内 緑の館",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "京都県",
-            "addressLocality": "梅小路公園内 緑の館"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-04-25",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "Our Plants ver.2.03"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "京都県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "京都",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/our-plants-2-03.html"
+    "description": "京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "Our Plants ver.2.03"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関西のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "Our Plants ver.2.03"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
+    <span>Our Plants ver.2.03</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>Our Plants ver.2.03</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-25" data-date-end="2026-04-25"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月25日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">京都</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>京都・梅小路公園で開催される植物即売会。珍奇植物や多肉植物が集まるイベント。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E4%BA%AC%E9%83%BD%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E4%BA%AC%E9%83%BD%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月25日（土）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">京都県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Our%20Plants%20ver.2.03&dates=20260425%2F20260426&location=%E4%BA%AC%E9%83%BD%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'our-plants-2-03';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/paludarium-collection-parcole-3rd-2026.html
+++ b/events/paludarium-collection-parcole-3rd-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>大阪府東大阪市で開催されるパルダリウム・植物コレクションイベント。珍奇植物やビバリウム関連の販売も。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=Link%21%20%E8%BF%91%E7%95%BF%E5%A4%A7%E5%AD%A6%E5%89%8D" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=Link%21%20%E8%BF%91%E7%95%BF%E5%A4%A7%E5%AD%A6%E5%89%8D&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関西</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC3%E5%9B%9E+%E3%83%91%E3%83%AB%E3%83%80%E3%83%AA%E3%82%A6%E3%83%A0%E3%82%B3%E3%83%AC%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3+%E3%83%91%E3%83%AB%E3%82%B3%E3%83%AC&dates=20260425%2F20260427&location=Link%21+%E8%BF%91%E7%95%BF%E5%A4%A7%E5%AD%A6%E5%89%8D" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC3%E5%9B%9E%20%E3%83%91%E3%83%AB%E3%83%80%E3%83%AA%E3%82%A6%E3%83%A0%E3%82%B3%E3%83%AC%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%20%E3%83%91%E3%83%AB%E3%82%B3%E3%83%AC&dates=20260425%2F20260427&location=Link%21%20%E8%BF%91%E7%95%BF%E5%A4%A7%E5%AD%A6%E5%89%8D" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'paludarium-collection-parcole-3rd-2026';

--- a/events/petit-to-wonder-market-2026.html
+++ b/events/petit-to-wonder-market-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>petit to Wonder Market | アガベイベントナビ</title>
   <meta name="description" content="埼玉・キヤッセ羽生で開催される小さな植物マーケット。多肉植物や雑貨のマルシェイベント。">
-  <meta name="keywords" content="petit to Wonder Market,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="petit to Wonder Market,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="petit to Wonder Market | アガベイベントナビ">
   <meta property="og:description" content="埼玉・キヤッセ羽生で開催される小さな植物マーケット。多肉植物や雑貨のマルシェイベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "埼玉",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "埼玉",
+        "addressRegion": "関東",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月29日（水）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">埼玉</span>
+        <span class="detail-meta-item">関東</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月29日（水）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=petit+to+Wonder+Market&dates=20260429%2F20260430&location=%E5%9F%BC%E7%8E%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=petit%20to%20Wonder%20Market&dates=20260429%2F20260430&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'petit-to-wonder-market-2026';

--- a/events/picnic-garden-vol20-aobayama-2026.html
+++ b/events/picnic-garden-vol20-aobayama-2026.html
@@ -13,36 +13,36 @@
   <link rel="canonical" href="https://agave-navi.com/events/picnic-garden-vol20-aobayama-2026.html">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ピクニックガーデン vol.20 in 青葉山公園 | アガベイベントナビ</title>
-  <meta name="description" content="宮城県仙台市・青葉山公園で開催される植物マルシェ第20回。多肉植物・観葉植物・雑貨が集まる。">
-  <meta name="keywords" content="ピクニックガーデン vol.20 in 青葉山公園,マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="description" content="宮城県仙台市・青葉山公園で開催される多肉植物マルシェ第20回。キングプランツ主催で10店舗以上の多肉植物専門店が出店し、珍しい品種の販売やワークショップを開催。">
+  <meta name="keywords" content="ピクニックガーデン vol.20 in 青葉山公園,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="ピクニックガーデン vol.20 in 青葉山公園 | アガベイベントナビ">
-  <meta property="og:description" content="宮城県仙台市・青葉山公園で開催される植物マルシェ第20回。多肉植物・観葉植物・雑貨が集まる。">
+  <meta property="og:description" content="宮城県仙台市・青葉山公園で開催される多肉植物マルシェ第20回。キングプランツ主催で10店舗以上の多肉植物専門店が出店し、珍しい品種の販売やワークショップを開催。">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agave-navi.com/events/picnic-garden-vol20-aobayama-2026.html">
   <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "ピクニックガーデン vol.20 in 青葉山公園",
-    "startDate": "",
-    "endDate": "",
+    "startDate": "2026-05-03",
+    "endDate": "2026-05-03",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "",
+      "name": "青葉山公園",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "",
+        "addressRegion": "宮城",
         "addressCountry": "JP"
       }
     },
-    "description": "宮城県仙台市・青葉山公園で開催される植物マルシェ第20回。多肉植物・観葉植物・雑貨が集まる。",
+    "description": "宮城県仙台市・青葉山公園で開催される多肉植物マルシェ第20回。キングプランツ主催で10店舗以上の多肉植物専門店が出店し、珍しい品種の販売やワークショップを開催。",
     "organizer": {
       "@type": "Organization",
       "name": "ピクニックガーデン vol.20 in 青葉山公園"
@@ -63,8 +63,8 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "イベント一覧",
-        "item": "https://agave-navi.com/"
+        "name": "東北のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E5%8C%97"
       },
       {
         "@type": "ListItem",
@@ -96,7 +96,7 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="/">イベント一覧</a> &gt;
+    <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt;
     <span>ピクニックガーデン vol.20 in 青葉山公園</span>
   </nav>
 
@@ -104,11 +104,11 @@
     <div class="detail-header">
       <h1>ピクニックガーデン vol.20 in 青葉山公園</h1>
       <div class="detail-meta">
-        <span class="detail-status-badge" data-date="" data-date-end=""></span>
+        <span class="detail-status-badge" data-date="2026-05-03" data-date-end="2026-05-03"></span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item"></span>
+        <span class="detail-meta-item">2026年5月3日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item"></span>
+        <span class="detail-meta-item">宮城</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -124,13 +124,22 @@
       <div class="detail-main">
         <div class="detail-section">
           <h2 class="detail-section-title">概要</h2>
-          <p>宮城県仙台市・青葉山公園で開催される植物マルシェ第20回。多肉植物・観葉植物・雑貨が集まる。</p>
+          <p>宮城県仙台市・青葉山公園で開催される多肉植物マルシェ第20回。キングプランツ主催で10店舗以上の多肉植物専門店が出店し、珍しい品種の販売やワークショップを開催。</p>
         </div>
 
 
 
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%9D%92%E8%91%89%E5%B1%B1%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E9%9D%92%E8%91%89%E5%B1%B1%E5%85%AC%E5%9C%92&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
         <div class="detail-back">
-          <a href="/" class="detail-back-link">イベント一覧に戻る</a>
+          <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
         </div>
       </div>
 
@@ -139,14 +148,22 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value"></span>
+            <span class="info-value">2026年5月3日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">青葉山公園</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>
-            <span class="info-value"></span>
+            <span class="info-value">東北</span>
           </div>
 
 
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%94%E3%82%AF%E3%83%8B%E3%83%83%E3%82%AF%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%20vol.20%20in%20%E9%9D%92%E8%91%89%E5%B1%B1%E5%85%AC%E5%9C%92&dates=20260503%2F20260504&location=%E9%9D%92%E8%91%89%E5%B1%B1%E5%85%AC%E5%9C%92" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
         </div>
 
 
@@ -189,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'picnic-garden-vol20-aobayama-2026';

--- a/events/picnic-garden-vol21-is-new-base-2026.html
+++ b/events/picnic-garden-vol21-is-new-base-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ピクニックガーデン vol.21 in I'S NEW BASE | アガベイベントナビ</title>
   <meta name="description" content="福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。">
-  <meta name="keywords" content="ピクニックガーデン vol.21 in I'S NEW BASE,マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="ピクニックガーデン vol.21 in I'S NEW BASE,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="ピクニックガーデン vol.21 in I'S NEW BASE | アガベイベントナビ">
   <meta property="og:description" content="福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>福島県会津若松市のI'S NEW BASEで開催される植物マルシェ第21回。多肉植物や観葉植物の即売。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=I%27S%20NEW%20BASE%EF%BC%88%E4%BC%9A%E6%B4%A5%E8%8B%A5%E6%9D%BE%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=I%27S%20NEW%20BASE%EF%BC%88%E4%BC%9A%E6%B4%A5%E8%8B%A5%E6%9D%BE%E5%B8%82%EF%BC%89&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">東北</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%94%E3%82%AF%E3%83%8B%E3%83%83%E3%82%AF%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3+vol.21+in+I%27S+NEW+BASE&dates=20260510%2F20260511&location=I%27S+NEW+BASE%EF%BC%88%E4%BC%9A%E6%B4%A5%E8%8B%A5%E6%9D%BE%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%94%E3%82%AF%E3%83%8B%E3%83%83%E3%82%AF%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%20vol.21%20in%20I%27S%20NEW%20BASE&dates=20260510%2F20260511&location=I%27S%20NEW%20BASE%EF%BC%88%E4%BC%9A%E6%B4%A5%E8%8B%A5%E6%9D%BE%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'picnic-garden-vol21-is-new-base-2026';

--- a/events/plant-freaks-4th-2026.html
+++ b/events/plant-freaks-4th-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PLANT FREAKS 4th | アガベイベントナビ</title>
   <meta name="description" content="植物好きのための大型フェスティバル。">
-  <meta name="keywords" content="PLANT FREAKS 4th,大型,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="PLANT FREAKS 4th,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="PLANT FREAKS 4th | アガベイベントナビ">
   <meta property="og:description" content="植物好きのための大型フェスティバル。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>植物好きのための大型フェスティバル。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E6%9D%B1%E4%BA%AC&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -156,18 +159,14 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANT+FREAKS+4th&dates=20260228%2F20260309&location=%E6%9D%B1%E4%BA%AC" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANT%20FREAKS%204th&dates=20260228%2F20260309&location=%E6%9D%B1%E4%BA%AC" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/plant_freaks_official/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@plant_freaks_official</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -207,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plant-freaks-4th-2026';

--- a/events/plant-freaks-special-2026-05.html
+++ b/events/plant-freaks-special-2026-05.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>塊根植物やアガベを中心とした珍奇植物の即売会。東京・錦糸町で開催されるPLANT FREAKSのスペシャル版。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%82%AA%E3%83%AA%E3%83%8A%E3%82%B9%E9%8C%A6%E7%B3%B8%E7%94%BA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E3%82%AA%E3%83%AA%E3%83%8A%E3%82%B9%E9%8C%A6%E7%B3%B8%E7%94%BA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANT+FREAKS+Special&dates=20260504%2F20260506&location=%E3%82%AA%E3%83%AA%E3%83%8A%E3%82%B9%E9%8C%A6%E7%B3%B8%E7%94%BA" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANT%20FREAKS%20Special&dates=20260504%2F20260506&location=%E3%82%AA%E3%83%AA%E3%83%8A%E3%82%B9%E9%8C%A6%E7%B3%B8%E7%94%BA" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plant-freaks-special-2026-05';

--- a/events/plants-fes-vol3.html
+++ b/events/plants-fes-vol3.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PLANTS FES vol.3 | アガベイベントナビ</title>
   <meta name="description" content="愛媛県で開催される植物フェス第3弾。多肉植物やアガベを中心とした即売・マルシェイベントです。">
-  <meta name="keywords" content="PLANTS FES vol.3,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="PLANTS FES vol.3,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="PLANTS FES vol.3 | アガベイベントナビ">
   <meta property="og:description" content="愛媛県で開催される植物フェス第3弾。多肉植物やアガベを中心とした即売・マルシェイベントです。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "愛媛",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "愛媛",
+        "addressRegion": "四国",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月19日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">愛媛</span>
+        <span class="detail-meta-item">四国</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月19日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">四国</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANTS+FES+vol.3&dates=20260419%2F20260420&location=%E6%84%9B%E5%AA%9B" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANTS%20FES%20vol.3&dates=20260419%2F20260420&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plants-fes-vol3';
@@ -219,6 +227,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/plants-garage-market-2026-spring.html
+++ b/events/plants-garage-market-2026-spring.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Plants garage market 2026 -SPRING &amp; SUMMER- | アガベイベントナビ</title>
   <meta name="description" content="大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。">
-  <meta name="keywords" content="Plants garage market 2026 -SPRING &amp; SUMMER-,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="Plants garage market 2026 -SPRING &amp; SUMMER-,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="Plants garage market 2026 -SPRING &amp; SUMMER- | アガベイベントナビ">
   <meta property="og:description" content="大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>大分県津久見市・イリノベ倉庫で開催される植物即売イベント。アガベ・サボテン・コーデックス・植木鉢など九州内外の店舗が出店し、フード出店も併設される2日間。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E3%82%A4%E3%83%AA%E3%83%8E%E3%83%99%E5%80%89%E5%BA%AB&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
@@ -145,8 +148,7 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年5月30日（土） 〜 5月31日（日）
-            30日 10:00〜17:00 / 31日 10:00〜15:00</span>
+            <span class="info-value">2026年5月30日（土） 〜 5月31日（日） 30日 10:00〜17:00 / 31日 10:00〜15:00</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
@@ -157,18 +159,17 @@
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Plants+garage+market+2026+-SPRING+%26+SUMMER-&dates=20260530%2F20260601&location=%E3%82%A4%E3%83%AA%E3%83%8E%E3%83%99%E5%80%89%E5%BA%AB" target="_blank" rel="noopener" class="gcal-btn">
+          <div class="info-row">
+            <span class="info-label">時間</span>
+            <span class="info-value">30日 10:00〜17:00 / 31日 10:00〜15:00</span>
+          </div>
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Plants%20garage%20market%202026%20-SPRING%20%26%20SUMMER-&dates=20260530%2F20260601&location=%E3%82%A4%E3%83%AA%E3%83%8E%E3%83%99%E5%80%89%E5%BA%AB" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/plants.garage.market/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@plants.garage.market</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -208,7 +209,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plants-garage-market-2026-spring';

--- a/events/plants-garage-market-2026-tsukumi.html
+++ b/events/plants-garage-market-2026-tsukumi.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,13 +127,7 @@
           <p>大分県津久見市・イリノベ倉庫で開催される植物即売会。塊根植物・アガベ・ビカクシダなど珍しい植物や植物関連雑貨を扱う店舗が集結。Oita Plants Farmとvandaka plantsの共同開催。</p>
         </div>
 
-        <div class="detail-section detail-instagram-embed">
-          <h2 class="detail-section-title">Instagram投稿</h2>
-          <div class="instagram-embed-wrap">
-            <iframe src="https://www.instagram.com/reel/DTEIXiekx1D/embed/" loading="lazy" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>
-          </div>
-          <p class="instagram-embed-link"><a href="https://www.instagram.com/reel/DTEIXiekx1D/" target="_blank" rel="noopener">Instagramで見る ↗</a></p>
-        </div>
+
 
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
@@ -142,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E3%82%A4%E3%83%AA%E3%83%8E%E3%83%99%E5%80%89%E5%BA%AB%EF%BC%88%E6%B4%A5%E4%B9%85%E8%A6%8B%E5%B8%82%EF%BC%89&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
@@ -164,7 +159,9 @@
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Plants+garage+market+2026&dates=20260530%2F20260601&location=%E3%82%A4%E3%83%AA%E3%83%8E%E3%83%99%E5%80%89%E5%BA%AB%EF%BC%88%E6%B4%A5%E4%B9%85%E8%A6%8B%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Plants%20garage%20market%202026&dates=20260530%2F20260601&location=%E3%82%A4%E3%83%AA%E3%83%8E%E3%83%99%E5%80%89%E5%BA%AB%EF%BC%88%E6%B4%A5%E4%B9%85%E8%A6%8B%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -209,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plants-garage-market-2026-tsukumi';

--- a/events/plants-garage-market.html
+++ b/events/plants-garage-market.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Plants Garage Market | アガベイベントナビ</title>
   <meta name="description" content="大分県津久見市で開催。アガベ・ビカクシダ・コーデックスなど珍奇植物の即売会。12時以降入場無料。">
-  <meta name="keywords" content="Plants Garage Market,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="Plants Garage Market,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="Plants Garage Market | アガベイベントナビ">
   <meta property="og:description" content="大分県津久見市で開催。アガベ・ビカクシダ・コーデックスなど珍奇植物の即売会。12時以降入場無料。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "大分",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "大分",
+        "addressRegion": "九州",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年5月3日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">大分</span>
+        <span class="detail-meta-item">九州</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年5月3日（日） 〜 5月4日（月）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Plants+Garage+Market&dates=20260503%2F20260505&location=%E5%A4%A7%E5%88%86" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Plants%20Garage%20Market&dates=20260503%2F20260505&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plants-garage-market';

--- a/events/plants-junkee-12th-2026.html
+++ b/events/plants-junkee-12th-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>プランツジャンキー 12th | アガベイベントナビ</title>
   <meta name="description" content="大阪南港ATCで開催される大型植物即売イベント第12回。アガベ、多肉植物、ビザールプランツなど多数出店。">
-  <meta name="keywords" content="プランツジャンキー 12th,即売会,大型,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="プランツジャンキー 12th,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="プランツジャンキー 12th | アガベイベントナビ">
   <meta property="og:description" content="大阪南港ATCで開催される大型植物即売イベント第12回。アガベ、多肉植物、ビザールプランツなど多数出店。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "プランツジャンキー 12th"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "未定"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>大阪南港ATCで開催される大型植物即売イベント第12回。アガベ、多肉植物、ビザールプランツなど多数出店。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%A4%A7%E9%98%AA%E5%8D%97%E6%B8%AFATC%20ITM%E6%A3%9F%204F%E7%89%B9%E8%A8%AD%E4%BC%9A%E5%A0%B4&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -152,34 +148,31 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年4月5日（日）
-            10:00〜16:00</span>
+            <span class="info-value">2026年4月5日（日） 10:00〜16:00</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
             <span class="info-value">大阪南港ATC ITM棟 4F特設会場</span>
           </div>
           <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関西</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">入場料</span>
             <span class="info-value">未定</span>
           </div>
           <div class="info-row">
-            <span class="info-label">開催地域</span>
-            <span class="info-value">関西</span>
+            <span class="info-label">時間</span>
+            <span class="info-value">10:00〜16:00</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84%E3%82%B8%E3%83%A3%E3%83%B3%E3%82%AD%E3%83%BC+12th&dates=20260405%2F20260406&location=%E5%A4%A7%E9%98%AA%E5%8D%97%E6%B8%AFATC+ITM%E6%A3%9F+4F%E7%89%B9%E8%A8%AD%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%97%E3%83%A9%E3%83%B3%E3%83%84%E3%82%B8%E3%83%A3%E3%83%B3%E3%82%AD%E3%83%BC%2012th&dates=20260405%2F20260406&location=%E5%A4%A7%E9%98%AA%E5%8D%97%E6%B8%AFATC%20ITM%E6%A3%9F%204F%E7%89%B9%E8%A8%AD%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/plants_junkee/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@plants_junkee</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -219,7 +212,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plants-junkee-12th-2026';

--- a/events/plants-plants-plants-2026.html
+++ b/events/plants-plants-plants-2026.html
@@ -13,17 +13,17 @@
   <link rel="canonical" href="https://agave-navi.com/events/plants-plants-plants-2026.html">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>PLANTS PLANTS PLANTS | アガベイベントナビ</title>
-  <meta name="description" content="岐阜・バムスガーデンで開催される植物即売イベント。アガベや多肉植物の専門ショップが出店。">
+  <meta name="description" content="岐阜県で開催される植物即売会。">
   <meta name="keywords" content="PLANTS PLANTS PLANTS,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="PLANTS PLANTS PLANTS | アガベイベントナビ">
-  <meta property="og:description" content="岐阜・バムスガーデンで開催される植物即売イベント。アガベや多肉植物の専門ショップが出店。">
+  <meta property="og:description" content="岐阜県で開催される植物即売会。">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agave-navi.com/events/plants-plants-plants-2026.html">
   <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,18 +35,43 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "岐阜",
+      "name": "岐阜県内",
       "address": {
         "@type": "PostalAddress",
         "addressRegion": "岐阜",
         "addressCountry": "JP"
       }
     },
-    "description": "岐阜・バムスガーデンで開催される植物即売イベント。アガベや多肉植物の専門ショップが出店。",
+    "description": "岐阜県で開催される植物即売会。",
     "organizer": {
       "@type": "Organization",
       "name": "PLANTS PLANTS PLANTS"
     }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "中部のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E9%83%A8"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "PLANTS PLANTS PLANTS"
+      }
+    ]
   }
   </script>
 </head>
@@ -59,19 +84,19 @@
         <span class="logo-jp">アガベイベントナビ</span>
       </a>
       <div class="header-actions">
-      <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-        <span class="blob-bg"></span>
-        <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-        <span class="ikitai-label">行きたい</span>
-        <span class="ikitai-badge" id="ikitaiBadge"></span>
-      </a>
-    </div>
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
     </div>
   </header>
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="/">即売会一覧</a> &gt;
+    <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt;
     <span>PLANTS PLANTS PLANTS</span>
   </nav>
 
@@ -80,9 +105,9 @@
       <h1>PLANTS PLANTS PLANTS</h1>
       <div class="detail-meta">
         <span class="detail-status-badge" data-date="2026-04-13" data-date-end="2026-04-13"></span>
-        <span class="detail-meta-dot">&middot;</span>
+        <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月13日（月）</span>
-        <span class="detail-meta-dot">&middot;</span>
+        <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">岐阜</span>
       </div>
       <div class="detail-header-actions">
@@ -99,13 +124,22 @@
       <div class="detail-main">
         <div class="detail-section">
           <h2 class="detail-section-title">概要</h2>
-          <p>岐阜・バムスガーデンで開催される植物即売イベント。アガベや多肉植物の専門ショップが出店。</p>
+          <p>岐阜県で開催される植物即売会。</p>
         </div>
 
 
 
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B2%90%E9%98%9C%E7%9C%8C%E5%86%85" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%B2%90%E9%98%9C%E7%9C%8C%E5%86%85&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
         <div class="detail-back">
-          <a href="/" class="detail-back-link">&larr; 即売会一覧に戻る</a>
+          <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
         </div>
       </div>
 
@@ -117,11 +151,17 @@
             <span class="info-value">2026年4月13日（月）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">岐阜県内</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">中部</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANTS+PLANTS+PLANTS&dates=20260413%2F20260414&location=%E5%B2%90%E9%98%9C" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=PLANTS%20PLANTS%20PLANTS&dates=20260413%2F20260414&location=%E5%B2%90%E9%98%9C%E7%9C%8C%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -134,15 +174,18 @@
     </div>
   </main>
 
-  <div class="ad-slot ad-slot-article-bottom">
-    <div class="ad-affiliate-area" id="adAffiliateArea">
-      <div class="aff-slot" id="affSlot1"></div>
-      <div class="aff-slot" id="affSlot2"></div>
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
     </div>
   </div>
 
   <div class="correction-notice">
-    <p>掲載情報に誤りがある場合は<a href="/contact.html">お問い合わせ</a>よりご連絡ください。</p>
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
   </div>
 
   <footer class="footer">
@@ -163,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'plants-plants-plants-2026';
@@ -186,11 +229,10 @@
         btn.classList.remove('is-fav');
         label.textContent = '行きたい';
       }
-      const countEl = document.getElementById('ikitaiBadge');
-      if (countEl) countEl.textContent = favs.length;
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/rhythms-of-life-2026.html
+++ b/events/rhythms-of-life-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>愛知県で開催される植物イベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E6%84%9B%E7%9F%A5%E7%9C%8C%E5%86%85" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E6%84%9B%E7%9F%A5%E7%9C%8C%E5%86%85&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">東海</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rhythms+of+Life&dates=20260530%2F20260601&location=%E6%84%9B%E7%9F%A5%E7%9C%8C%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rhythms%20of%20Life&dates=20260530%2F20260601&location=%E6%84%9B%E7%9F%A5%E7%9C%8C%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'rhythms-of-life-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/saikiengei-fukuyama-marche-2026.html
+++ b/events/saikiengei-fukuyama-marche-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SaikiEngei to 福山deマルシェ | アガベイベントナビ</title>
   <meta name="description" content="愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。">
-  <meta name="keywords" content="SaikiEngei to 福山deマルシェ,マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="SaikiEngei to 福山deマルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="SaikiEngei to 福山deマルシェ | アガベイベントナビ">
   <meta property="og:description" content="愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>愛媛県今治市・しまなみアースランドで開催される植物マルシェ。多肉植物・アガベが集まるイベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%81%97%E3%81%BE%E3%81%AA%E3%81%BF%E3%82%A2%E3%83%BC%E3%82%B9%E3%83%A9%E3%83%B3%E3%83%89" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E3%81%97%E3%81%BE%E3%81%AA%E3%81%BF%E3%82%A2%E3%83%BC%E3%82%B9%E3%83%A9%E3%83%B3%E3%83%89&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">四国</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=SaikiEngei+to+%E7%A6%8F%E5%B1%B1de%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260517%2F20260518&location=%E3%81%97%E3%81%BE%E3%81%AA%E3%81%BF%E3%82%A2%E3%83%BC%E3%82%B9%E3%83%A9%E3%83%B3%E3%83%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=SaikiEngei%20to%20%E7%A6%8F%E5%B1%B1de%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260517%2F20260518&location=%E3%81%97%E3%81%BE%E3%81%AA%E3%81%BF%E3%82%A2%E3%83%BC%E3%82%B9%E3%83%A9%E3%83%B3%E3%83%89" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'saikiengei-fukuyama-marche-2026';

--- a/events/seiseihatake-2026.html
+++ b/events/seiseihatake-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "実生畑でつかまえて 2026"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>東京・日本橋で開催される植物即売会。実生から育成した珍奇植物が集まるイベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=Toky%20%28%E6%97%A5%E6%9C%AC%E6%A9%8B%E4%B9%85%E6%9D%BE%E7%94%BA%29&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -159,15 +155,16 @@
             <span class="info-value">Toky (日本橋久松町)</span>
           </div>
           <div class="info-row">
-            <span class="info-label">入場料</span>
-            <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%AE%9F%E7%94%9F%E7%95%91%E3%81%A7%E3%81%A4%E3%81%8B%E3%81%BE%E3%81%88%E3%81%A6+2026&dates=20260404%2F20260405&location=Toky+%28%E6%97%A5%E6%9C%AC%E6%A9%8B%E4%B9%85%E6%9D%BE%E7%94%BA%29" target="_blank" rel="noopener" class="gcal-btn">
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%AE%9F%E7%94%9F%E7%95%91%E3%81%A7%E3%81%A4%E3%81%8B%E3%81%BE%E3%81%88%E3%81%A6%202026&dates=20260404%2F20260405&location=Toky%20%28%E6%97%A5%E6%9C%AC%E6%A9%8B%E4%B9%85%E6%9D%BE%E7%94%BA%29" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -212,7 +209,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'seiseihatake-2026';

--- a/events/sendai-agave-shop-vol2.html
+++ b/events/sendai-agave-shop-vol2.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/sendai-agave-shop-vol2.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>仙台竜舌露店 Vol.2 | アガベイベントナビ</title>
-    <meta name="description" content="宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。">
-    <meta property="og:title" content="仙台竜舌露店 Vol.2">
-    <meta property="og:description" content="宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/sendai-agave-shop-vol2.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt; 仙台竜舌露店 Vol.2</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>仙台竜舌露店 Vol.2</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-06-27">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年06月27日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">宮城県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>仙台竜舌露店 Vol.2は宮城県で開催される植物イベントです。宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=宮城%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年06月27日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">宮城県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=仙台竜舌露店 Vol.2&dates=20260627%2F20260628&location=宮城&details=仙台竜舌露店 Vol.2+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/sendai-agave-shop-vol2.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>仙台竜舌露店 Vol.2 | アガベイベントナビ</title>
+  <meta name="description" content="宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。">
+  <meta name="keywords" content="仙台竜舌露店 Vol.2,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="仙台竜舌露店 Vol.2 | アガベイベントナビ">
+  <meta property="og:description" content="宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/sendai-agave-shop-vol2.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "仙台竜舌露店 Vol.2",
-    "description": "宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。",
     "startDate": "2026-06-27",
-    "location": {
-        "@type": "Place",
-        "name": "虹色路店前 ガレージスペース",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "宮城県",
-            "addressLocality": "虹色路店前 ガレージスペース"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-06-27",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "仙台竜舌露店 Vol.2"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "宮城県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "宮城",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/sendai-agave-shop-vol2.html"
+    "description": "宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "仙台竜舌露店 Vol.2"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "東北のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E5%8C%97"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "仙台竜舌露店 Vol.2"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E6%9D%B1%E5%8C%97">東北のイベント</a> &gt;
+    <span>仙台竜舌露店 Vol.2</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>仙台竜舌露店 Vol.2</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-06-27" data-date-end="2026-06-27"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年6月27日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">宮城</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>宮城県仙台市で開催されるアガベやリュウゼツランの専門マルシェ。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%AE%AE%E5%9F%8E%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%AE%AE%E5%9F%8E%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年6月27日（土）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">宮城県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">東北</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E4%BB%99%E5%8F%B0%E7%AB%9C%E8%88%8C%E9%9C%B2%E5%BA%97%20Vol.2&dates=20260627%2F20260628&location=%E5%AE%AE%E5%9F%8E%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'sendai-agave-shop-vol2';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/shimamura-mini-soransai-2026.html
+++ b/events/shimamura-mini-soransai-2026.html
@@ -1,310 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/shimamura-mini-soransai-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ミニ草乱祭 in シマムラ園芸 | アガベイベントナビ</title>
-    <meta name="description" content="多肉植物・コーデックス・珍しい品種を扱う園芸イベント。2日間で40店舗が参加。音楽やマーケットも楽しめる植物の祭典。">
-    <meta property="og:title" content="ミニ草乱祭 in シマムラ園芸">
-    <meta property="og:description" content="多肉植物・コーデックス・珍しい品種を扱う園芸イベント。2日間で40店舗が参加。音楽やマーケットも楽しめる植物の祭典。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/shimamura-mini-soransai-2026.html">
-    <meta property="og:image" content="https://soransai.com/wp-content/uploads/2026/01/IMG_8558.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; ミニ草乱祭 in シマムラ園芸</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://soransai.com/wp-content/uploads/2026/01/IMG_8558.jpg" onerror="this.parentElement.style.display='none'" alt="ミニ草乱祭 in シマムラ園芸" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>ミニ草乱祭 in シマムラ園芸</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-06-20" data-date-end="2026-04-19">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年6月20日（土）（土）-19日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">埼玉県越谷市</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>ミニ草乱祭は、シマムラ園芸の第2ハウスで開催される多肉植物とコーデックスの専門イベントです。2日間開催で、全国から集まった40店舗の出店者が珍しい品種を持ち寄ります。</p>
-                    <p>日替わり出店により、毎日異なるラインアップを楽しむことができるため、2日間通って来場するのもおすすめです。多肉植物・コーデックス・珍しい品種が揃い、植物愛好家にとって見逃せないイベント。</p>
-                    <p>音楽やマーケットも開催されるため、植物の販売に加えて、フードやグッズなども楽しめる充実した祭典です。春の植物シーズンを存分に楽しめるイベントとなっています。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=シマムラ園芸,埼玉県越谷市南荻島1401&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年6月20日（土）（土）-19日（日）<br>9:00〜16:00</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">シマムラ園芸 第2ハウス</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">埼玉県越谷市南荻島1401</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">入場無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">出店数</span>
-                        <span class="info-value">40店舗（日替わり出店）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">開催地域</span>
-                        <span class="info-value">関東</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://soransai.com/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9F%E3%83%8B%E8%8D%89%E4%B9%B1%E7%A5%AD+in+%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8&dates=20260620T090000%2F20260419T170000&location=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%2C+%E5%9F%BC%E7%8E%89%E7%9C%8C&details=%E3%83%9F%E3%83%8B%E8%8D%89%E4%B9%B1%E7%A5%AD+in+%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会,マルシェ"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/shimamura-mini-soransai-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ミニ草乱祭 in シマムラ園芸 | アガベイベントナビ</title>
+  <meta name="description" content="シマムラ園芸第2ハウスにて。日替わりで各日20店舗が出店。多肉・コーデックス・珍奇植物が揃う。入場無料。">
+  <meta name="keywords" content="ミニ草乱祭 in シマムラ園芸,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="ミニ草乱祭 in シマムラ園芸 | アガベイベントナビ">
+  <meta property="og:description" content="シマムラ園芸第2ハウスにて。日替わりで各日20店舗が出店。多肉・コーデックス・珍奇植物が揃う。入場無料。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/shimamura-mini-soransai-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "ミニ草乱祭 in シマムラ園芸",
-    "description": "多肉植物・コーデックス・珍しい品種を扱う園芸イベント。日替わり出店で2日間合計40店舗が参加。",
-    "startDate": "2026-04-18T09:00:00+09:00",
-    "endDate": "2026-04-19T16:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "シマムラ園芸 第2ハウス",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "埼玉県",
-            "addressLocality": "越谷市",
-            "streetAddress": "南荻島1401"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2026-06-20",
+    "endDate": "2026-04-19",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "organizer": {
-        "@type": "Organization",
-        "name": "ミニ草乱祭 in シマムラ園芸",
-        "url": "https://soransai.com/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "シマムラ園芸 第2ハウス",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "埼玉",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/shimamura-mini-soransai-2026.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/shimamura-mini-soransai-2026.html"
+    "description": "シマムラ園芸第2ハウスにて。日替わりで各日20店舗が出店。多肉・コーデックス・珍奇植物が揃う。入場無料。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "ミニ草乱祭 in シマムラ園芸"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "ミニ草乱祭 in シマムラ園芸"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>ミニ草乱祭 in シマムラ園芸</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>ミニ草乱祭 in シマムラ園芸</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-06-20" data-date-end="2026-04-19"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年6月20日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">埼玉</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>シマムラ園芸第2ハウスにて。日替わりで各日20店舗が出店。多肉・コーデックス・珍奇植物が揃う。入場無料。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%2C%E5%9F%BC%E7%8E%89%E7%9C%8C%E8%B6%8A%E8%B0%B7%E5%B8%82%E5%8D%97%E8%8D%BB%E5%B3%B61401" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%2C%E5%9F%BC%E7%8E%89%E7%9C%8C%E8%B6%8A%E8%B0%B7%E5%B8%82%E5%8D%97%E8%8D%BB%E5%B3%B61401&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年6月20日（土） 〜 4月19日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">シマムラ園芸 第2ハウス</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%83%9F%E3%83%8B%E8%8D%89%E4%B9%B1%E7%A5%AD%20in%20%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8&dates=20260620%2F20260420&location=%E3%82%B7%E3%83%9E%E3%83%A0%E3%83%A9%E5%9C%92%E8%8A%B8%20%E7%AC%AC2%E3%83%8F%E3%82%A6%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'shimamura-mini-soransai-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/shoku-sai-vol9-izumo-2026.html
+++ b/events/shoku-sai-vol9-izumo-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>島根県出雲市・飯塚農園で開催される植物イベント第9回。多肉植物やアガベの即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%A3%AF%E5%A1%9A%E8%BE%B2%E5%9C%92%EF%BC%88%E5%87%BA%E9%9B%B2%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E9%A3%AF%E5%A1%9A%E8%BE%B2%E5%9C%92%EF%BC%88%E5%87%BA%E9%9B%B2%E5%B8%82%EF%BC%89&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B8%AD%E5%9B%BD" class="detail-back-link">中国のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">中国</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A4%8D%E7%A5%AD+vol.9&dates=20260505%2F20260506&location=%E9%A3%AF%E5%A1%9A%E8%BE%B2%E5%9C%92%EF%BC%88%E5%87%BA%E9%9B%B2%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A4%8D%E7%A5%AD%20vol.9&dates=20260505%2F20260506&location=%E9%A3%AF%E5%A1%9A%E8%BE%B2%E5%9C%92%EF%BC%88%E5%87%BA%E9%9B%B2%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'shoku-sai-vol9-izumo-2026';

--- a/events/shokubutsu-hyakkaten-2026.html
+++ b/events/shokubutsu-hyakkaten-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>植物百貨展 | アガベイベントナビ</title>
   <meta name="description" content="東京で開催される大型植物展示即売会。">
-  <meta name="keywords" content="植物百貨展,即売会,展示会,大型,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="植物百貨展,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="植物百貨展 | アガベイベントナビ">
   <meta property="og:description" content="東京で開催される大型植物展示即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>東京で開催される大型植物展示即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -154,6 +158,8 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
+
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A4%8D%E7%89%A9%E7%99%BE%E8%B2%A8%E5%B1%95&dates=20260417%2F20260419&location=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%86%85" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'shokubutsu-hyakkaten-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/shokuenseisai-5th.html
+++ b/events/shokuenseisai-5th.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>植縁祭 5th | アガベイベントナビ</title>
   <meta name="description" content="愛媛県伊予市で開催される植物イベント。多肉植物やサボテンの即売会。">
-  <meta name="keywords" content="植縁祭 5th,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="植縁祭 5th,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="植縁祭 5th | アガベイベントナビ">
   <meta property="og:description" content="愛媛県伊予市で開催される植物イベント。多肉植物やサボテンの即売会。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +46,6 @@
     "organizer": {
       "@type": "Organization",
       "name": "植縁祭 5th"
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "JPY",
-      "availability": "https://schema.org/InStock",
-      "description": "無料"
     }
   }
   </script>
@@ -134,6 +127,8 @@
           <p>愛媛県伊予市で開催される植物イベント。多肉植物やサボテンの即売会。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -141,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E3%81%AA%E3%81%8B%E3%82%84%E3%81%BE%E3%83%95%E3%83%A9%E3%83%AF%E3%83%BC%E3%83%8F%E3%82%A6%E3%82%B9&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
@@ -159,15 +155,16 @@
             <span class="info-value">なかやまフラワーハウス</span>
           </div>
           <div class="info-row">
-            <span class="info-label">入場料</span>
-            <span class="info-value">無料</span>
-          </div>
-          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">四国</span>
           </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A4%8D%E7%B8%81%E7%A5%AD+5th&dates=20260404%2F20260406&location=%E3%81%AA%E3%81%8B%E3%82%84%E3%81%BE%E3%83%95%E3%83%A9%E3%83%AF%E3%83%BC%E3%83%8F%E3%82%A6%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A4%8D%E7%B8%81%E7%A5%AD%205th&dates=20260404%2F20260406&location=%E3%81%AA%E3%81%8B%E3%82%84%E3%81%BE%E3%83%95%E3%83%A9%E3%83%AF%E3%83%BC%E3%83%8F%E3%82%A6%E3%82%B9" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -212,7 +209,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'shokuenseisai-5th';

--- a/events/sippo-de-marche-fukushima-2026.html
+++ b/events/sippo-de-marche-fukushima-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>シッポdeマルシェ | アガベイベントナビ</title>
   <meta name="description" content="福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。">
-  <meta name="keywords" content="シッポdeマルシェ,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="シッポdeマルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="シッポdeマルシェ | アガベイベントナビ">
   <meta property="og:description" content="福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>福島県の四季の里で開催されるマルシェイベント。多肉植物や雑貨が集まる地域マルシェ。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%9B%9B%E5%AD%A3%E3%81%AE%E9%87%8C%20%E6%97%A7%E8%BE%B2%E6%9D%91%E3%83%AC%E3%82%B9%E3%83%88%E3%83%A9%E3%83%B3" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E5%9B%9B%E5%AD%A3%E3%81%AE%E9%87%8C%20%E6%97%A7%E8%BE%B2%E6%9D%91%E3%83%AC%E3%82%B9%E3%83%88%E3%83%A9%E3%83%B3&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E6%9D%B1%E5%8C%97" class="detail-back-link">東北のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">東北</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%82%B7%E3%83%83%E3%83%9Dde%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260426%2F20260427&location=%E5%9B%9B%E5%AD%A3%E3%81%AE%E9%87%8C+%E6%97%A7%E8%BE%B2%E6%9D%91%E3%83%AC%E3%82%B9%E3%83%88%E3%83%A9%E3%83%B3" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%82%B7%E3%83%83%E3%83%9Dde%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260426%2F20260427&location=%E5%9B%9B%E5%AD%A3%E3%81%AE%E9%87%8C%20%E6%97%A7%E8%BE%B2%E6%9D%91%E3%83%AC%E3%82%B9%E3%83%88%E3%83%A9%E3%83%B3" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'sippo-de-marche-fukushima-2026';

--- a/events/sora-to-taiyo-marche-2026.html
+++ b/events/sora-to-taiyo-marche-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>空と太陽のマルシェ | アガベイベントナビ</title>
   <meta name="description" content="茨城空港で開催されるグリーンマルシェ。多肉植物やハンドメイド雑貨が集まる屋外イベント。">
-  <meta name="keywords" content="空と太陽のマルシェ,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="空と太陽のマルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="空と太陽のマルシェ | アガベイベントナビ">
   <meta property="og:description" content="茨城空港で開催されるグリーンマルシェ。多肉植物やハンドメイド雑貨が集まる屋外イベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "茨城",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "茨城",
+        "addressRegion": "関東",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月12日（日）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">茨城</span>
+        <span class="detail-meta-item">関東</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月12日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%A9%BA%E3%81%A8%E5%A4%AA%E9%99%BD%E3%81%AE%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260412%2F20260413&location=%E8%8C%A8%E5%9F%8E" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%A9%BA%E3%81%A8%E5%A4%AA%E9%99%BD%E3%81%AE%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260412%2F20260413&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'sora-to-taiyo-marche-2026';

--- a/events/sumi-no-engei-2026-05-02.html
+++ b/events/sumi-no-engei-2026-05-02.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E6%9D%B1%E4%BA%AC&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,6 +158,8 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
+
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E9%9A%85%E3%81%AE%E5%9C%92%E8%97%9D&dates=20260502%2F20260503&location=%E6%9D%B1%E4%BA%AC" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'sumi-no-engei-2026-05-02';

--- a/events/sumi-no-engei-2026-05-09.html
+++ b/events/sumi-no-engei-2026-05-09.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>東京で開催される植物販売イベント。アガベ・塊根植物・多肉植物を扱う。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E6%9D%B1%E4%BA%AC&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -155,6 +158,8 @@
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
+
+
 
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E9%9A%85%E3%81%AE%E5%9C%92%E8%97%9D&dates=20260509%2F20260510&location=%E6%9D%B1%E4%BA%AC" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'sumi-no-engei-2026-05-09';

--- a/events/tanifes-vol6-asahikawa-2026.html
+++ b/events/tanifes-vol6-asahikawa-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>くうふくあったマルシェ 多肉FESTIVAL VOL.6 | アガベイベントナビ</title>
   <meta name="description" content="北海道・旭川の道の駅で開催される多肉植物フェスティバル第6回。北海道最大級の多肉植物即売イベント。">
-  <meta name="keywords" content="くうふくあったマルシェ 多肉FESTIVAL VOL.6,即売会,マルシェ,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="くうふくあったマルシェ 多肉FESTIVAL VOL.6,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="くうふくあったマルシェ 多肉FESTIVAL VOL.6 | アガベイベントナビ">
   <meta property="og:description" content="北海道・旭川の道の駅で開催される多肉植物フェスティバル第6回。北海道最大級の多肉植物即売イベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,7 +35,7 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "北海道",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
         "addressRegion": "北海道",
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E5%8C%97%E6%B5%B7%E9%81%93" class="detail-back-link">北海道のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月29日（水）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">北海道</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%81%8F%E3%81%86%E3%81%B5%E3%81%8F%E3%81%82%E3%81%A3%E3%81%9F%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7+%E5%A4%9A%E8%82%89FESTIVAL+VOL.6&dates=20260429%2F20260430&location=%E5%8C%97%E6%B5%B7%E9%81%93" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%81%8F%E3%81%86%E3%81%B5%E3%81%8F%E3%81%82%E3%81%A3%E3%81%9F%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7%20%E5%A4%9A%E8%82%89FESTIVAL%20VOL.6&dates=20260429%2F20260430&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'tanifes-vol6-asahikawa-2026';

--- a/events/taniku-midori-marche-nabana-2026.html
+++ b/events/taniku-midori-marche-nabana-2026.html
@@ -1,309 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/taniku-midori-marche-nabana-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>多肉とみどりのマルシェ in なばなの里 | アガベイベントナビ</title>
-    <meta name="description" content="なばなの里で開催される多肉とみどりのマルシェ。第11回目の開催。多肉植物、花苗、ガーデニンググッズなどの販売。ワークショップも開催。">
-    <meta property="og:title" content="多肉とみどりのマルシェ in なばなの里">
-    <meta property="og:description" content="なばなの里で開催される多肉とみどりのマルシェ。第11回目の開催。多肉植物、花苗、ガーデニンググッズなどの販売。ワークショップも開催。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/taniku-midori-marche-nabana-2026.html">
-    <meta property="og:image" content="https://www.nagashima-onsen.co.jp/nabana/img/ogp.png">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E6%9D%B1%E6%B5%B7">東海のイベント</a> &gt; 多肉とみどりのマルシェ in なばなの里</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://www.nagashima-onsen.co.jp/nabana/img/ogp.png" onerror="this.parentElement.style.display='none'" alt="多肉とみどりのマルシェ in なばなの里" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>多肉とみどりのマルシェ in なばなの里</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2018-05-19" data-date-end="2026-04-12">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年4月10日（金）-12日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">三重県桑名市</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>多肉とみどりのマルシェ in なばなの里は、三重県の人気スポット「なばなの里」で開催される第11回目のイベントです。多肉植物、花苗、ガーデニンググッズ、クラフト雑貨など、多彩な商品が揃います。</p>
-                    <p>会場ではワークショップも開催され、多肉アレンジメントや苔玉づくりなど、参加者が自分で作成を楽しめるコンテンツが充実しています。植物初心者から愛好家まで、幅広い層が楽しめるイベントです。</p>
-                    <p>なばなの里のB駐車場エリアでの開催となります。春のお出かけにぴったりな、植物とみどりに囲まれた充実の3日間です。入場無料でご来場いただけます。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=なばなの里,桑名市&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">4月10日（金）-12日（日）<br>9:00〜17:00</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">なばなの里 B駐車場エリア</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">三重県桑名市</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">開催回数</span>
-                        <span class="info-value">第11回</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">ステータス</span>
-                        <span class="info-value">開催予定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://www.nagashima-onsen.co.jp/nabana/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A4%9A%E8%82%89%E3%81%A8%E3%81%BF%E3%81%A9%E3%82%8A%E3%81%AE%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7+in+%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C&dates=20260410T090000%2F20260412T170000&location=%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C%2C+%E4%B8%89%E9%87%8D%E7%9C%8C&details=%E5%A4%9A%E8%82%89%E3%81%A8%E3%81%BF%E3%81%A9%E3%82%8A%E3%81%AE%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7+in+%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/taniku-midori-marche-nabana-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>多肉とみどりのマルシェ in なばなの里 | アガベイベントナビ</title>
+  <meta name="description" content="第12回開催。なばなの里B駐車場特設会場にて。多肉アレンジ体験（¥500）や苔玉づくり（¥1,000）のワークショップも。入場無料。">
+  <meta name="keywords" content="多肉とみどりのマルシェ in なばなの里,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="多肉とみどりのマルシェ in なばなの里 | アガベイベントナビ">
+  <meta property="og:description" content="第12回開催。なばなの里B駐車場特設会場にて。多肉アレンジ体験（¥500）や苔玉づくり（¥1,000）のワークショップも。入場無料。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/taniku-midori-marche-nabana-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "多肉とみどりのマルシェ in なばなの里",
-    "description": "なばなの里で開催される第11回の多肉とみどりのマルシェ。多肉植物、花苗、ガーデニンググッズなどの販売。ワークショップも開催。",
-    "startDate": "2026-04-10T09:00:00+09:00",
-    "endDate": "2026-04-12T17:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "なばなの里 B駐車場エリア",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "三重県",
-            "addressLocality": "桑名市"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "startDate": "2018-05-19",
+    "endDate": "2026-04-12",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "organizer": {
-        "@type": "Organization",
-        "name": "多肉とみどりのマルシェ in なばなの里",
-        "url": "https://www.nagashima-onsen.co.jp/nabana/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "なばなの里 B駐車場エリア",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "三重",
+        "addressCountry": "JP"
+      }
     },
-    "image": "https://agave-navi.com/images/ogp/taniku-midori-marche-nabana-2026.jpg",
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/taniku-midori-marche-nabana-2026.html"
+    "description": "第12回開催。なばなの里B駐車場特設会場にて。多肉アレンジ体験（¥500）や苔玉づくり（¥1,000）のワークショップも。入場無料。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "多肉とみどりのマルシェ in なばなの里"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "東海のイベント",
+        "item": "https://agave-navi.com/?region=%E6%9D%B1%E6%B5%B7"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "多肉とみどりのマルシェ in なばなの里"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E6%9D%B1%E6%B5%B7">東海のイベント</a> &gt;
+    <span>多肉とみどりのマルシェ in なばなの里</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>多肉とみどりのマルシェ in なばなの里</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2018-05-19" data-date-end="2026-04-12"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2018年5月19日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">三重</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>第12回開催。なばなの里B駐車場特設会場にて。多肉アレンジ体験（¥500）や苔玉づくり（¥1,000）のワークショップも。入場無料。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C%2C%E6%A1%91%E5%90%8D%E5%B8%82" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C%2C%E6%A1%91%E5%90%8D%E5%B8%82&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E6%9D%B1%E6%B5%B7" class="detail-back-link">東海のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2018年5月19日（土） 〜 4月12日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">なばなの里 B駐車場エリア</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">東海</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A4%9A%E8%82%89%E3%81%A8%E3%81%BF%E3%81%A9%E3%82%8A%E3%81%AE%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7%20in%20%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C&dates=20180519%2F20260413&location=%E3%81%AA%E3%81%B0%E3%81%AA%E3%81%AE%E9%87%8C%20B%E9%A7%90%E8%BB%8A%E5%A0%B4%E3%82%A8%E3%83%AA%E3%82%A2" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'taniku-midori-marche-nabana-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/taniku-moromoro-2026-spring.html
+++ b/events/taniku-moromoro-2026-spring.html
@@ -1,290 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/taniku-moromoro-2026-spring.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>多肉もろもろ市場 2026春 | アガベイベントナビ</title>
-    <meta name="description" content="多肉植物愛好家のための専門マーケット。全国のブリーダーや販売者が集結する即売会。">
-    <meta property="og:title" content="多肉もろもろ市場 2026春">
-    <meta property="og:description" content="多肉植物愛好家のための専門マーケット。全国のブリーダーや販売者が集結する即売会。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/taniku-moromoro-2026-spring.html">
-    <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt; 多肉もろもろ市場 2026春</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>多肉もろもろ市場 2026春</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-15">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年4月中旬（予定）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">兵庫県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>多肉もろもろ市場は、多肉植物愛好家のための専門マーケットです。全国の多肉植物ブリーダーや販売者が集まる即売会で、様々な品種が手に入ります。エケベリア、グラプトペタルム、センペルビウムなど、豊富な多肉植物ラインナップが揃います。</p>
-                    <p>春の開催では、冬から春への季節の変わり目に人気が高まる多肉植物が多数出品されます。初心者向けの手軽な品種から、コレクター向けの希少品種まで、多様なニーズに応えるイベントです。ブリーダーと直接話し、栽培のコツや品種の特徴を学ぶことができます。</p>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年4月中旬（予定）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">道の駅 北はりまエコミュージアム</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">エリア</span>
-                        <span class="info-value">兵庫県西脇市</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">未定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://tanikumoromoro.denku-travel.com/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A4%9A%E8%82%89%E3%82%82%E3%82%8D%E3%82%82%E3%82%8D%E5%B8%82%E5%A0%B4+2026%E6%98%A5&dates=20260415T100000%2F20260415T170000&location=%E6%9D%B1%E4%BA%AC%E9%83%BD&details=%E5%A4%9A%E8%82%89%E3%82%82%E3%82%8D%E3%82%82%E3%82%8D%E5%B8%82%E5%A0%B4+2026%E6%98%A5+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会,マルシェ"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/taniku-moromoro-2026-spring.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>多肉もろもろ市場 2026春 | アガベイベントナビ</title>
+  <meta name="description" content="兵庫県西脇市で開催される多肉植物専門の青空即売会。全国のブリーダーや販売者が集まる人気イベント。">
+  <meta name="keywords" content="多肉もろもろ市場 2026春,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="多肉もろもろ市場 2026春 | アガベイベントナビ">
+  <meta property="og:description" content="兵庫県西脇市で開催される多肉植物専門の青空即売会。全国のブリーダーや販売者が集まる人気イベント。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/taniku-moromoro-2026-spring.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "多肉もろもろ市場 2026春",
-    "description": "兵庫県西脇市で開催される多肉植物専門の青空即売会。全国のブリーダーや販売者が集まる人気イベント。",
-    "startDate": "2026-04-15T09:00:00+09:00",
-    "endDate": "2026-04-15T17:00:00+09:00",
-    "image": "https://agave-navi.com/images/ogp/taniku-moromoro-2026-spring.jpg",
-    "location": {
-        "@type": "Place",
-        "name": "道の駅 北はりまエコミュージアム",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "兵庫県"
-        }
-    },
-    "organizer": {
-        "@type": "Organization",
-        "name": "多肉もろもろ市場 2026春",
-        "url": "https://tanikumoromoro.denku-travel.com/"
-    },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/taniku-moromoro-2026-spring.html"
-    },
+    "startDate": "2026-04-15",
+    "endDate": "2026-04-15",
+    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
-    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode"
-}
-    </script>
+    "location": {
+      "@type": "Place",
+      "name": "道の駅 北はりまエコミュージアム",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "兵庫",
+        "addressCountry": "JP"
+      }
+    },
+    "description": "兵庫県西脇市で開催される多肉植物専門の青空即売会。全国のブリーダーや販売者が集まる人気イベント。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "多肉もろもろ市場 2026春"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "近畿のイベント",
+        "item": "https://agave-navi.com/?region=%E8%BF%91%E7%95%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "多肉もろもろ市場 2026春"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt;
+    <span>多肉もろもろ市場 2026春</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>多肉もろもろ市場 2026春</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-15" data-date-end=""></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月15日（水）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">兵庫</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>兵庫県西脇市で開催される多肉植物専門の青空即売会。全国のブリーダーや販売者が集まる人気イベント。</p>
+        </div>
 
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%81%93%E3%81%AE%E9%A7%85%20%E5%8C%97%E3%81%AF%E3%82%8A%E3%81%BE%E3%82%A8%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%82%A2%E3%83%A0" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E9%81%93%E3%81%AE%E9%A7%85%20%E5%8C%97%E3%81%AF%E3%82%8A%E3%81%BE%E3%82%A8%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%82%A2%E3%83%A0&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月15日（水）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">道の駅 北はりまエコミュージアム</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">近畿</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">未定</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%A4%9A%E8%82%89%E3%82%82%E3%82%8D%E3%82%82%E3%82%8D%E5%B8%82%E5%A0%B4%202026%E6%98%A5&dates=20260415%2F20260416&location=%E9%81%93%E3%81%AE%E9%A7%85%20%E5%8C%97%E3%81%AF%E3%82%8A%E3%81%BE%E3%82%A8%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%82%A2%E3%83%A0" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'taniku-moromoro-2026-spring';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/tanushimaru-garden-shokuyo-osei-vol4-2026.html
+++ b/events/tanushimaru-garden-shokuyo-osei-vol4-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>福岡県久留米市・田主丸ガーデンで開催される植物販売会。アガベ・多肉植物・珍奇植物の即売イベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E7%94%B0%E4%B8%BB%E4%B8%B8%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E9%A7%90%E8%BB%8A%E5%A0%B4" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E7%94%B0%E4%B8%BB%E4%B8%B8%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E9%A7%90%E8%BB%8A%E5%A0%B4&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E4%B9%9D%E5%B7%9E" class="detail-back-link">九州のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">九州</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%94%B0%E4%B8%BB%E4%B8%B8%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E6%A4%8D%E7%89%A9%E8%B2%A9%E5%A3%B2%E4%BC%9A+%E6%A4%8D%E6%AC%B2%E6%97%BA%E7%9B%9B+Vol.4&dates=20260425%2F20260427&location=%E7%94%B0%E4%B8%BB%E4%B8%B8%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E9%A7%90%E8%BB%8A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%94%B0%E4%B8%BB%E4%B8%B8%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E6%A4%8D%E7%89%A9%E8%B2%A9%E5%A3%B2%E4%BC%9A%20%E6%A4%8D%E6%AC%B2%E6%97%BA%E7%9B%9B%20Vol.4&dates=20260425%2F20260427&location=%E7%94%B0%E4%B8%BB%E4%B8%B8%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E9%A7%90%E8%BB%8A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'tanushimaru-garden-shokuyo-osei-vol4-2026';

--- a/events/tenkaichi-2026.html
+++ b/events/tenkaichi-2026.html
@@ -1,301 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/tenkaichi-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>第6回 天下一植物界 BORDER BREAK BEYOND | アガベイベントナビ</title>
-    <meta name="description" content="西日本最大級の植物イベント。アガベ、サボテン、多肉植物から熱帯植物、洋蘭まで。">
-    <meta property="og:title" content="第6回 天下一植物界 BORDER BREAK BEYOND">
-    <meta property="og:description" content="西日本最大級の植物イベント。アガベ、サボテン、多肉植物から熱帯植物、洋蘭まで。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/tenkaichi-2026.html">
-    <meta property="og:image" content="https://no1plantae.com/images/0/9/9/5/1/099514bd64e0fd9ea8df64efc26b32ff4463f7c5-img7956.jpeg">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt; 第6回 天下一植物界 BORDER BREAK BEYOND</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://no1plantae.com/images/0/9/9/5/1/099514bd64e0fd9ea8df64efc26b32ff4463f7c5-img7956.jpeg" onerror="this.parentElement.style.display='none'" alt="第6回 天下一植物界" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>第6回 天下一植物界 BORDER BREAK BEYOND</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-23" data-date-end="2026-05-24">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月23日（土）-24日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">大阪府</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>第6回「天下一植物界 BORDER BREAK BEYOND」は、西日本最大級の植物イベントです。アガベ、サボテン、多肉植物から熱帯植物、洋蘭、伝統園芸まで、あらゆる植物ジャンルの境界を超えた大規模な展示即売会。ここでは、異なる植物文化が一堂に会し、新たな出会いと発見の場が創出されます。</p>
-                    <p>全国から著名なナーサリー、生産者、ブリーダーが参加予定。普段は手に入らない希少植物から、初心者にも人気の入門品種まで、幅広いラインナップが揃います。各出展者のブースでは、植物の栽培方法や品種の特徴について直接相談でき、単なる買い物だけでなく植物文化の学びと深化の貴重な機会となります。</p>
-                    <p>ジャンルを超えた植物愛好家が集まるこのイベントを通じて、新しい植物の世界への扉が開きます。5月の京セラドーム大阪での開催は、関西圏を中心とする植物ファン必見の2日間です。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=大阪府大阪市西区千代崎3丁目中2-1&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年5月23日（土）-24日（日）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">京セラドーム大阪 スカイホール A/B</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">エリア</span>
-                        <span class="info-value">大阪府大阪市西区</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">前売りチケット制（詳細は公式サイト）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://no1plantae.com/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC6%E5%9B%9E+%E5%A4%A9%E4%B8%8B%E4%B8%80%E6%A4%8D%E7%89%A9%E7%95%8C&dates=20260523T090000%2F20260524T170000&location=%E4%BA%AC%E3%82%BB%E3%83%A9%E3%83%89%E3%83%BC%E3%83%A0%E5%A4%A7%E9%98%AA%2C+%E5%A4%A7%E9%98%AA%E5%BA%9C&details=%E7%AC%AC6%E5%9B%9E+%E5%A4%A9%E4%B8%8B%E4%B8%80%E6%A4%8D%E7%89%A9%E7%95%8C+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,展示会,即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/tenkaichi-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>第6回 天下一植物界 | アガベイベントナビ</title>
+  <meta name="description" content="京セラドーム大阪にて。約75店舗が出店する大型植物即売会。ジャンルの垣根を超えた植物の祭典。">
+  <meta name="keywords" content="第6回 天下一植物界,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="第6回 天下一植物界 | アガベイベントナビ">
+  <meta property="og:description" content="京セラドーム大阪にて。約75店舗が出店する大型植物即売会。ジャンルの垣根を超えた植物の祭典。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/tenkaichi-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": "第6回 天下一植物界 BORDER BREAK BEYOND",
-    "description": "西日本最大級の植物イベント。アガベやサボテン、多肉植物から熱帯植物、洋蘭、伝統園芸まで、あらゆる植物ジャンルが集結。",
-    "startDate": "2026-05-23T10:00:00+09:00",
-    "endDate": "2026-05-24T18:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "京セラドーム大阪",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "大阪府",
-            "addressLocality": "大阪市西区",
-            "streetAddress": "千代崎3丁目中2-1"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "name": "第6回 天下一植物界",
+    "startDate": "2026-05-23",
+    "endDate": "2026-05-24",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "image": "https://agave-navi.com/images/ogp/tenkaichi-2026.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "第6回 天下一植物界",
-        "url": "https://no1plantae.com/"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "京セラドーム大阪 スカイホール A/B",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "大阪",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/tenkaichi-2026.html"
+    "description": "京セラドーム大阪にて。約75店舗が出店する大型植物即売会。ジャンルの垣根を超えた植物の祭典。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "第6回 天下一植物界"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "近畿のイベント",
+        "item": "https://agave-navi.com/?region=%E8%BF%91%E7%95%BF"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "第6回 天下一植物界"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E8%BF%91%E7%95%BF">近畿のイベント</a> &gt;
+    <span>第6回 天下一植物界</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>第6回 天下一植物界</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-23" data-date-end="2026-05-24"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月23日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">大阪</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>京セラドーム大阪にて。約75店舗が出店する大型植物即売会。ジャンルの垣根を超えた植物の祭典。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%A4%A7%E9%98%AA%E5%BA%9C%E5%A4%A7%E9%98%AA%E5%B8%82%E8%A5%BF%E5%8C%BA%E5%8D%83%E4%BB%A3%E5%B4%8E3%E4%B8%81%E7%9B%AE%E4%B8%AD2-1" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%A4%A7%E9%98%AA%E5%BA%9C%E5%A4%A7%E9%98%AA%E5%B8%82%E8%A5%BF%E5%8C%BA%E5%8D%83%E4%BB%A3%E5%B4%8E3%E4%B8%81%E7%9B%AE%E4%B8%AD2-1&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E8%BF%91%E7%95%BF" class="detail-back-link">近畿のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月23日（土） 〜 5月24日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">京セラドーム大阪 スカイホール A/B</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">近畿</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">前売りチケット制（詳細は公式サイト）</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E7%AC%AC6%E5%9B%9E%20%E5%A4%A9%E4%B8%8B%E4%B8%80%E6%A4%8D%E7%89%A9%E7%95%8C&dates=20260523%2F20260525&location=%E4%BA%AC%E3%82%BB%E3%83%A9%E3%83%89%E3%83%BC%E3%83%A0%E5%A4%A7%E9%98%AA%20%E3%82%B9%E3%82%AB%E3%82%A4%E3%83%9B%E3%83%BC%E3%83%AB%20A/B" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'tenkaichi-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/the-botanical-show.html
+++ b/events/the-botanical-show.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>THE BOTANICAL SHOW 5th | アガベイベントナビ</title>
   <meta name="description" content="湘南平塚アウトレットで開催されるボタニカルイベント。">
-  <meta name="keywords" content="THE BOTANICAL SHOW 5th,即売会,展示会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="THE BOTANICAL SHOW 5th,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="THE BOTANICAL SHOW 5th | アガベイベントナビ">
   <meta property="og:description" content="湘南平塚アウトレットで開催されるボタニカルイベント。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>湘南平塚アウトレットで開催されるボタニカルイベント。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=THE%20OUTLETS%20SHONAN%20HIRATSUKA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
@@ -156,7 +159,9 @@
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=THE+BOTANICAL+SHOW+5th&dates=20260404%2F20260406&location=THE+OUTLETS+SHONAN+HIRATSUKA" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=THE%20BOTANICAL%20SHOW%205th&dates=20260404%2F20260406&location=THE%20OUTLETS%20SHONAN%20HIRATSUKA" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -201,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'the-botanical-show';

--- a/events/the-plants-episode-9.html
+++ b/events/the-plants-episode-9.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/the-plants-episode-9.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>THE PLANTS - Episode 9 | アガベイベントナビ</title>
-    <meta name="description" content="香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。">
-    <meta property="og:title" content="THE PLANTS - Episode 9">
-    <meta property="og:description" content="香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/the-plants-episode-9.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt; THE PLANTS - Episode 9</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>THE PLANTS - Episode 9</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-26">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月26日（日）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">香川県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>THE PLANTS - Episode 9は香川県で開催される植物イベントです。香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=香川%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年04月26日（日）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">香川県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=THE PLANTS - Episode 9&dates=20260426%2F20260427&location=香川&details=THE PLANTS - Episode 9+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="即売会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/the-plants-episode-9.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>THE PLANTS - Episode 9 | アガベイベントナビ</title>
+  <meta name="description" content="香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。">
+  <meta name="keywords" content="THE PLANTS - Episode 9,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="THE PLANTS - Episode 9 | アガベイベントナビ">
+  <meta property="og:description" content="香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/the-plants-episode-9.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "THE PLANTS - Episode 9",
-    "description": "香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。",
     "startDate": "2026-04-26",
-    "location": {
-        "@type": "Place",
-        "name": "Gori House",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "香川県",
-            "addressLocality": "Gori House"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-04-26",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "THE PLANTS - Episode 9"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "香川県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "香川",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/the-plants-episode-9.html"
+    "description": "香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "THE PLANTS - Episode 9"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "四国のイベント",
+        "item": "https://agave-navi.com/?region=%E5%9B%9B%E5%9B%BD"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "THE PLANTS - Episode 9"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E5%9B%9B%E5%9B%BD">四国のイベント</a> &gt;
+    <span>THE PLANTS - Episode 9</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>THE PLANTS - Episode 9</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-26" data-date-end="2026-04-26"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月26日（日）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">香川</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>香川県観音寺市で開催されるプランツイベント。珍奇植物の即売会。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%A6%99%E5%B7%9D%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E9%A6%99%E5%B7%9D%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月26日（日）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">香川県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">四国</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=THE%20PLANTS%20-%20Episode%209&dates=20260426%2F20260427&location=%E9%A6%99%E5%B7%9D%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'the-plants-episode-9';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/tilly-fes-vol5-2026.html
+++ b/events/tilly-fes-vol5-2026.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tilly FES Vol.5 | アガベイベントナビ</title>
   <meta name="description" content="チランジア（エアプランツ）専門イベント。SPACE BANKSIAにて全国のティランジア専門ショップが集結。">
-  <meta name="keywords" content="Tilly FES Vol.5,即売会,展示会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="Tilly FES Vol.5,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="Tilly FES Vol.5 | アガベイベントナビ">
   <meta property="og:description" content="チランジア（エアプランツ）専門イベント。SPACE BANKSIAにて全国のティランジア専門ショップが集結。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,10 +35,10 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "東京",
+      "name": "会場未定",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "東京",
+        "addressRegion": "関東",
         "addressCountry": "JP"
       }
     },
@@ -108,7 +108,7 @@
         <span class="detail-meta-dot"></span>
         <span class="detail-meta-item">2026年4月11日（土）</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">東京</span>
+        <span class="detail-meta-item">関東</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -129,6 +129,8 @@
 
 
 
+
+
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
         </div>
@@ -142,11 +144,17 @@
             <span class="info-value">2026年4月11日（土） 〜 4月12日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">会場未定</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">関東</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Tilly+FES+Vol.5&dates=20260411%2F20260413&location=%E6%9D%B1%E4%BA%AC" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Tilly%20FES%20Vol.5&dates=20260411%2F20260413&location=" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +199,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'tilly-fes-vol5-2026';

--- a/events/tosa-muroto-cactus-8th-2026.html
+++ b/events/tosa-muroto-cactus-8th-2026.html
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,12 +127,16 @@
           <p>土佐室戸サボテンクラブ主催のサボテン・多肉植物展示会。第八回目の開催。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E9%AB%98%E7%9F%A5%E7%9C%8C%E5%AE%A4%E6%88%B8%E5%B8%82%E5%86%85%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
             <iframe src="https://www.google.com/maps?q=%E9%AB%98%E7%9F%A5%E7%9C%8C%E5%AE%A4%E6%88%B8%E5%B8%82%E5%86%85%E4%BC%9A%E5%A0%B4&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E5%9B%9B%E5%9B%BD" class="detail-back-link">四国のイベントに戻る</a>
@@ -155,7 +159,9 @@
             <span class="info-value">四国</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%9C%9F%E4%BD%90%E5%AE%A4%E6%88%B8%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%82%AF%E3%83%A9%E3%83%96+%E7%AC%AC%E5%85%AB%E5%9B%9E%E5%B1%95%E7%A4%BA%E4%BC%9A&dates=20260426%2F20260427&location=%E9%AB%98%E7%9F%A5%E7%9C%8C%E5%AE%A4%E6%88%B8%E5%B8%82%E5%86%85%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%9C%9F%E4%BD%90%E5%AE%A4%E6%88%B8%E3%82%B5%E3%83%9C%E3%83%86%E3%83%B3%E3%82%AF%E3%83%A9%E3%83%96%20%E7%AC%AC%E5%85%AB%E5%9B%9E%E5%B1%95%E7%A4%BA%E4%BC%9A&dates=20260426%2F20260427&location=%E9%AB%98%E7%9F%A5%E7%9C%8C%E5%AE%A4%E6%88%B8%E5%B8%82%E5%86%85%E4%BC%9A%E5%A0%B4" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -200,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'tosa-muroto-cactus-8th-2026';
@@ -228,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/wakayama-green-marche.html
+++ b/events/wakayama-green-marche.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>和歌山グリーンマルシェ | アガベイベントナビ</title>
   <meta name="description" content="多肉植物やサボテンを中心とした青果品が集まる地域マルシェ。新鮮な植物の即売会です。">
-  <meta name="keywords" content="和歌山グリーンマルシェ,マルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="keywords" content="和歌山グリーンマルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="和歌山グリーンマルシェ | アガベイベントナビ">
   <meta property="og:description" content="多肉植物やサボテンを中心とした青果品が集まる地域マルシェ。新鮮な植物の即売会です。">
   <meta property="og:type" content="article">
@@ -23,7 +23,7 @@
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -127,6 +127,8 @@
           <p>多肉植物やサボテンを中心とした青果品が集まる地域マルシェ。新鮮な植物の即売会です。</p>
         </div>
 
+
+
         <div class="detail-map">
           <h2 class="detail-section-title">会場</h2>
           <div class="map-container">
@@ -134,6 +136,7 @@
             <iframe src="https://www.google.com/maps?q=%E5%92%8C%E6%AD%8C%E5%B1%B1&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
           </div>
         </div>
+
 
         <div class="detail-back">
           <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
@@ -156,18 +159,14 @@
             <span class="info-value">関西</span>
           </div>
 
+
+
           <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E5%92%8C%E6%AD%8C%E5%B1%B1%E3%82%B0%E3%83%AA%E3%83%BC%E3%83%B3%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260329%2F20260330&location=%E5%92%8C%E6%AD%8C%E5%B1%B1" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
 
-        <div class="detail-instagram-card">
-          <h3><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg> 公式Instagram</h3>
-          <a href="https://www.instagram.com/wakayama_green_marche/" target="_blank" rel="noopener" class="instagram-account-link">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
-            <span class="ig-gradient">@wakayama_green_marche</span>
-          </a>
-        </div>
+
 
       </div>
 
@@ -207,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'wakayama-green-marche';

--- a/events/wasshoi-marche.html
+++ b/events/wasshoi-marche.html
@@ -1,286 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/wasshoi-marche.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>わっしょいマルシェ | アガベイベントナビ</title>
-    <meta name="description" content="岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。">
-    <meta property="og:title" content="わっしょいマルシェ">
-    <meta property="og:description" content="岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/wasshoi-marche.html">
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt; わっしょいマルシェ</div>
-
-    <main class="detail-page">
-        <div class="detail-header">
-            <h1>わっしょいマルシェ</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-04-25">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年04月25日（土）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">岐阜県</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>わっしょいマルシェは岐阜県で開催される植物イベントです。岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。</p>
-                    <p>このイベントは植物愛好家にとって重要な機会となります。珍しい品種の発見や、植物の購入、そして愛好家同士の交流の場として機能しています。</p>
-                    <p>詳細な日程や出店者情報は、直接主催者にお問い合わせいただくことをお勧めします。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=岐阜%E7%9C%8C&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">2026年04月25日（土）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">岐阜県</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">無料</span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=わっしょいマルシェ&dates=20260425%2F20260426&location=岐阜&details=わっしょいマルシェ+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-
-
-            </div>
-
-            <div class="affiliate-section" data-tags="マルシェ"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/wasshoi-marche.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>わっしょいマルシェ | アガベイベントナビ</title>
+  <meta name="description" content="岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。">
+  <meta name="keywords" content="わっしょいマルシェ,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="わっしょいマルシェ | アガベイベントナビ">
+  <meta property="og:description" content="岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/wasshoi-marche.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
     "name": "わっしょいマルシェ",
-    "description": "岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。",
     "startDate": "2026-04-25",
-    "location": {
-        "@type": "Place",
-        "name": "四国山香りの森公園 香りドーム",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "岐阜県",
-            "addressLocality": "四国山香りの森公園 香りドーム"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "endDate": "2026-04-25",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "isAccessibleForFree": true,
-    "image": "https://agave-navi.com/images/ogp/default.jpg",
-    "organizer": {
-        "@type": "Organization",
-        "name": "わっしょいマルシェ"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "岐阜県",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "岐阜",
+        "addressCountry": "JP"
+      }
     },
-    "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/wasshoi-marche.html"
+    "description": "岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。",
+    "organizer": {
+      "@type": "Organization",
+      "name": "わっしょいマルシェ"
     }
-}
-    </script>
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "中部のイベント",
+        "item": "https://agave-navi.com/?region=%E4%B8%AD%E9%83%A8"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "わっしょいマルシェ"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E4%B8%AD%E9%83%A8">中部のイベント</a> &gt;
+    <span>わっしょいマルシェ</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>わっしょいマルシェ</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-04-25" data-date-end="2026-04-25"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年4月25日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">岐阜</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>岐阜県山県市で開催されるマルシェ。植物や地域の特産品が揃うイベント。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E5%B2%90%E9%98%9C%E7%9C%8C" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E5%B2%90%E9%98%9C%E7%9C%8C&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E4%B8%AD%E9%83%A8" class="detail-back-link">中部のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年4月25日（土）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">岐阜県</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">中部</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">無料</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E3%82%8F%E3%81%A3%E3%81%97%E3%82%87%E3%81%84%E3%83%9E%E3%83%AB%E3%82%B7%E3%82%A7&dates=20260425%2F20260426&location=%E5%B2%90%E9%98%9C%E7%9C%8C" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'wasshoi-marche';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/events/yamaguchi-plants-market-2026.html
+++ b/events/yamaguchi-plants-market-2026.html
@@ -13,17 +13,17 @@
   <link rel="canonical" href="https://agave-navi.com/events/yamaguchi-plants-market-2026.html">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YAMAGUCHI PLANTS MARKET 2026 | アガベイベントナビ</title>
-  <meta name="description" content="山口・ときわ公園で開催される植物マーケット。ときわミュージアム内で多肉植物やアガベの展示販売。">
-  <meta name="keywords" content="YAMAGUCHI PLANTS MARKET 2026,即売会,展示会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta name="description" content="山口県最大の植物イベント第4回。32店舗が集結し、珍しい植物や作家鉢が並ぶ。">
+  <meta name="keywords" content="YAMAGUCHI PLANTS MARKET 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
   <meta property="og:title" content="YAMAGUCHI PLANTS MARKET 2026 | アガベイベントナビ">
-  <meta property="og:description" content="山口・ときわ公園で開催される植物マーケット。ときわミュージアム内で多肉植物やアガベの展示販売。">
+  <meta property="og:description" content="山口県最大の植物イベント第4回。32店舗が集結し、珍しい植物や作家鉢が並ぶ。">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://agave-navi.com/events/yamaguchi-plants-market-2026.html">
   <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260329c">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -35,14 +35,14 @@
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "山口",
+      "name": "ときわ公園 ときわミュージアム（山口県宇部市）",
       "address": {
         "@type": "PostalAddress",
         "addressRegion": "山口",
         "addressCountry": "JP"
       }
     },
-    "description": "山口・ときわ公園で開催される植物マーケット。ときわミュージアム内で多肉植物やアガベの展示販売。",
+    "description": "山口県最大の植物イベント第4回。32店舗が集結し、珍しい植物や作家鉢が並ぶ。",
     "organizer": {
       "@type": "Organization",
       "name": "YAMAGUCHI PLANTS MARKET 2026"
@@ -124,9 +124,18 @@
       <div class="detail-main">
         <div class="detail-section">
           <h2 class="detail-section-title">概要</h2>
-          <p>山口・ときわ公園で開催される植物マーケット。ときわミュージアム内で多肉植物やアガベの展示販売。</p>
+          <p>山口県最大の植物イベント第4回。32店舗が集結し、珍しい植物や作家鉢が並ぶ。</p>
         </div>
 
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%81%A8%E3%81%8D%E3%82%8F%E5%85%AC%E5%9C%92%20%E3%81%A8%E3%81%8D%E3%82%8F%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%82%A2%E3%83%A0%EF%BC%88%E5%B1%B1%E5%8F%A3%E7%9C%8C%E5%AE%87%E9%83%A8%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E3%81%A8%E3%81%8D%E3%82%8F%E5%85%AC%E5%9C%92%20%E3%81%A8%E3%81%8D%E3%82%8F%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%82%A2%E3%83%A0%EF%BC%88%E5%B1%B1%E5%8F%A3%E7%9C%8C%E5%AE%87%E9%83%A8%E5%B8%82%EF%BC%89&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
 
 
         <div class="detail-back">
@@ -142,11 +151,17 @@
             <span class="info-value">2026年4月25日（土） 〜 4月26日（日）</span>
           </div>
           <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">ときわ公園 ときわミュージアム（山口県宇部市）</span>
+          </div>
+          <div class="info-row">
             <span class="info-label">開催地域</span>
             <span class="info-value">中国</span>
           </div>
 
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=YAMAGUCHI+PLANTS+MARKET+2026&dates=20260425%2F20260427&location=%E5%B1%B1%E5%8F%A3" target="_blank" rel="noopener" class="gcal-btn">
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=YAMAGUCHI%20PLANTS%20MARKET%202026&dates=20260425%2F20260427&location=%E3%81%A8%E3%81%8D%E3%82%8F%E5%85%AC%E5%9C%92%20%E3%81%A8%E3%81%8D%E3%82%8F%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%B8%E3%82%A2%E3%83%A0%EF%BC%88%E5%B1%B1%E5%8F%A3%E7%9C%8C%E5%AE%87%E9%83%A8%E5%B8%82%EF%BC%89" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -191,7 +206,7 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260330b"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
   <script src="../ads.js"></script>
   <script>
     const SLUG = 'yamaguchi-plants-market-2026';
@@ -219,6 +234,5 @@
     }
     updateFavUI();
   </script>
-<script src="/official-links.js"></script>
 </body>
 </html>

--- a/events/yokohama-flower-garden-fes-2026.html
+++ b/events/yokohama-flower-garden-fes-2026.html
@@ -1,308 +1,241 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NKY8V1H8HY"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-NKY8V1H8HY');
-</script>
-<meta name="google-site-verification" content="23j_bxcczlGhWRVrlfh94HO0hYGk9qxQzfbew60oWB0" />
-    <link rel="canonical" href="https://agave-navi.com/events/yokohama-flower-garden-fes-2026.html">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>横浜フラワー&ガーデンフェスティバル 2026 | アガベイベントナビ</title>
-    <meta name="description" content="パシフィコ横浜で開催される日本最大規模のガーデニングイベント。バラ・花・植物のディスプレイ、物販、ワークショップなど。多肉植物の出店ブースも充実。">
-    <meta property="og:title" content="横浜フラワー&ガーデンフェスティバル 2026">
-    <meta property="og:description" content="パシフィコ横浜で開催される日本最大規模のガーデニングイベント。バラ・花・植物のディスプレイ、物販、ワークショップなど。多肉植物の出店ブースも充実。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://agave-navi.com/events/yokohama-flower-garden-fes-2026.html">
-    <meta property="og:image" content="https://yfg-fes.jp/assets/img/slide/main_title26.webp">
-
-    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="icon" type="image/x-icon" href="../favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-    <link rel="stylesheet" href="../style.css?v=20260329c">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
-</head>
-<body>
-    <header class="header">
-                <div class="header-inner">
-            <a href="/" class="logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-                <span class="logo-jp">アガベイベントナビ</span>
-            </a>
-            <div class="header-actions">
-                <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
-                    <span class="blob-bg"></span>
-                    <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-                    <span class="ikitai-label">行きたい</span>
-                    <span class="ikitai-badge" id="ikitaiBadge"></span>
-                </a>
-                <button class="menu-toggle" id="menuToggle" aria-label="メニュー">
-                    <span></span><span></span><span></span>
-                </button>
-            </div>
-        </div>
-    </header>
-
-        <nav class="nav-overlay" id="navOverlay">
-        <div class="nav-overlay-inner">
-            <a href="/">ホーム</a>
-            <a href="../calendar.html">カレンダー</a>
-            <a href="../map.html">マップ</a>
-            <a href="../about.html">サイトについて</a>
-            <a href="../contact.html">お問い合わせ</a>
-            <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            <a href="../ikitai.html" class="nav-ikitai-link"><svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> 行きたいリスト</a>
-        </div>
-    </nav>
-
-    <div class="breadcrumb">
-        <a href="/">ホーム</a> &gt; <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt; 横浜フラワー&ガーデンフェスティバル 2026</div>
-
-    <main class="detail-page">
-        <div class="detail-hero">
-            <img src="https://yfg-fes.jp/assets/img/slide/main_title26.webp" onerror="this.parentElement.style.display='none'" alt="横浜フラワー&ガーデンフェスティバル 2026" class="detail-hero-img">
-        </div>
-        <div class="detail-header">
-            <h1>横浜フラワー&ガーデンフェスティバル 2026</h1>
-            <div class="detail-meta">
-                <span class="detail-status-badge" data-date="2026-05-02" data-date-end="2026-05-04">開催予定</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">2026年5月2日（土）-4日（月・祝）</span>
-                <span class="detail-meta-dot"></span>
-                <span class="detail-meta-item">神奈川県横浜市</span>
-                        </div>
-            <div class="detail-header-actions">
-                <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
-                <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
-                <span id="favLabel">行きたい</span>
-            </button>
-</div>
-        </div>
-
-        <div class="detail-body">
-            <div class="detail-main">
-                <div class="detail-section">
-                    <h2 class="detail-section-title">イベント概要</h2>
-                    <p>横浜フラワー&ガーデンフェスティバル 2026は、パシフィコ横浜で開催される日本最大規模のガーデニングイベントです。バラ、花、植物のディスプレイや特別展示が会場いっぱいに広がります。</p>
-                    <p>物販ブースでは多くの園芸店や専門ショップが出店し、ガーデニング雑貨や植物の購入ができます。特に多肉植物の出店ブースが充実しており、珍しい品種との出会いも期待できます。</p>
-                    <p>ワークショップも多数開催され、初心者から上級者まで参加できるコンテンツが揃います。ゴールデンウイークの時期での開催となるため、ご家族連れにも最適なイベントとなっています。</p>
-                </div>
-
-                <div class="detail-map">
-                    <h2 class="detail-section-title">会場</h2>
-                    <iframe src="https://maps.google.com/maps?q=パシフィコ横浜,横浜市西区&output=embed" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-
-                <div class="detail-back">
-                    <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
-                </div>
-            </div>
-
-            <div class="detail-sidebar">
-                <div class="detail-info-card">
-                    <h3>Event Info</h3>
-                    <div class="info-row">
-                        <span class="info-label">日時</span>
-                        <span class="info-value">5月2日（土）-4日（月・祝）<br>10:00〜17:00（最終日16:00まで）</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">会場</span>
-                        <span class="info-value">パシフィコ横浜 展示ホールA・B</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">住所</span>
-                        <span class="info-value">神奈川県横浜市西区</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">入場料</span>
-                        <span class="info-value">前売¥1,600 / 当日¥2,000 / 中学生以下無料</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">特徴</span>
-                        <span class="info-value">日本最大規模、多肉植物ブース充実</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">ステータス</span>
-                        <span class="info-value">開催予定</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">公式</span>
-                        <span class="info-value"><a href="https://yfg-fes.jp/" target="_blank" rel="noopener" style="color:var(--accent-pop);text-decoration:none">公式サイト →</a></span>
-                    </div>
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%AA%E6%B5%9C%E3%83%95%E3%83%A9%E3%83%AF%E3%83%BC%26%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E3%83%95%E3%82%A7%E3%82%B9%E3%83%86%E3%82%A3%E3%83%90%E3%83%AB+2026&dates=20260502T100000%2F20260504T170000&location=%E3%83%91%E3%82%B7%E3%83%95%E3%82%A3%E3%82%B3%E6%A8%AA%E6%B5%9C%2C+%E7%A5%9E%E5%A5%88%E5%B7%9D%E7%9C%8C&details=%E6%A8%AA%E6%B5%9C%E3%83%95%E3%83%A9%E3%83%AF%E3%83%BC%26%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E3%83%95%E3%82%A7%E3%82%B9%E3%83%86%E3%82%A3%E3%83%90%E3%83%AB+2026+-+%E3%82%A2%E3%82%AC%E3%83%99%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%83%8A%E3%83%93+https%3A%2F%2Fagave-navi.com%2F" target="_blank" rel="noopener" class="gcal-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-                        Googleカレンダーに追加
-                    </a>
-                </div>
-                
-
-            </div>
-
-            <div class="affiliate-section" data-tags="大型,マルシェ,展示会"></div>
-        </div>
-    </main>
-
-    <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
-        <!-- Google AdSense: 記事下レスポンシブ広告 -->
-        <!-- TODO: パブリッシャーID取得後にアドセンスコードを挿入 -->
-    </div>
-
-    
-    <!-- 広告・アフィリエイトエリア -->
-    <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
-        <div class="aff-slot" data-count="5"></div>
-        <div class="ad-slot">
-            <span class="ad-slot-label">広告</span>
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-                 data-ad-slot="0987654321"
-                 data-ad-format="auto"
-                 data-full-width-responsive="true"></ins>
-        </div>
-    </div>
-
-    <div class="correction-notice">
-        <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
-    </div>
-
-    <footer class="footer">
-        <div class="footer-inner">
-            <div class="footer-logo">
-                <span class="logo-en">AGAVE EVENT NAVI</span>
-            </div>
-            <nav class="footer-nav">
-                <a href="../about.html">サイトについて</a>
-                <a href="../calendar.html">カレンダー</a>
-                <a href="../map.html">マップ</a>
-                <a href="../privacy.html">プライバシーポリシー</a>
-                <a href="../terms.html">利用規約</a>
-                <a href="../disclaimer.html">免責事項</a>
-                <a href="../operator.html">運営者情報</a>
-                <a href="../contact.html">お問い合わせ</a>
-                <a href="../listing.html">掲載申請</a>
-                <a href="https://www.instagram.com/m.z.plants/" target="_blank">INSTAGRAM</a>
-            </nav>
-            <p class="footer-copy">&copy; 2026 AGAVE EVENT NAVI</p>
-        </div>
-    </footer>
-
-    <script type="application/ld+json">
-    {
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKY0V1H0HY"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-MKY0V1H0HY');
+  </script>
+  <meta charset="UTF-8">
+  <link rel="canonical" href="https://agave-navi.com/events/yokohama-flower-garden-fes-2026.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>横浜フラワー&amp;ガーデンフェスティバル 2026 | アガベイベントナビ</title>
+  <meta name="description" content="パシフィコ横浜で開催。GREEN×EXPO 2027プレ企画。バラの展示・ガーデンデザイン・物販。前売¥1,600。">
+  <meta name="keywords" content="横浜フラワー&amp;ガーデンフェスティバル 2026,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="横浜フラワー&amp;ガーデンフェスティバル 2026 | アガベイベントナビ">
+  <meta property="og:description" content="パシフィコ横浜で開催。GREEN×EXPO 2027プレ企画。バラの展示・ガーデンデザイン・物販。前売¥1,600。">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://agave-navi.com/events/yokohama-flower-garden-fes-2026.html">
+  <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
+  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <script type="application/ld+json">
+  {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": "横浜フラワー&ガーデンフェスティバル 2026",
-    "description": "パシフィコ横浜で開催される日本最大規模のガーデニングイベント。バラ・花・植物のディスプレイ、物販、ワークショップなど。多肉植物の出店ブースも充実。",
-    "startDate": "2026-05-02T10:00:00+09:00",
-    "endDate": "2026-05-04T16:00:00+09:00",
-    "location": {
-        "@type": "Place",
-        "name": "パシフィコ横浜 展示ホールA・B",
-        "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "JP",
-            "addressRegion": "神奈川県",
-            "addressLocality": "横浜市西区"
-        }
-    },
-    "eventStatus": "https://schema.org/EventScheduled",
+    "name": "横浜フラワー&amp;ガーデンフェスティバル 2026",
+    "startDate": "2026-05-02",
+    "endDate": "2026-05-04",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "offers": {
-        "@type": "Offer",
-        "price": "1600",
-        "priceCurrency": "JPY",
-        "availability": "https://schema.org/InStock",
-        "url": "https://agave-navi.com/events/yokohama-flower-garden-fes-2026.html"
+    "eventStatus": "https://schema.org/EventScheduled",
+    "location": {
+      "@type": "Place",
+      "name": "パシフィコ横浜 展示ホールA・B",
+      "address": {
+        "@type": "PostalAddress",
+        "addressRegion": "神奈川",
+        "addressCountry": "JP"
+      }
     },
+    "description": "パシフィコ横浜で開催。GREEN×EXPO 2027プレ企画。バラの展示・ガーデンデザイン・物販。前売¥1,600。",
     "organizer": {
-        "@type": "Organization",
-        "name": "横浜フラワー&ガーデンフェスティバル 2026",
-        "url": "https://yfg-fes.jp/"
-    },
-    "image": "https://agave-navi.com/images/ogp/yokohama-flower-garden-fes-2026.jpg"
-}
-    </script>
+      "@type": "Organization",
+      "name": "横浜フラワー&amp;ガーデンフェスティバル 2026"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "ホーム",
+        "item": "https://agave-navi.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "関東のイベント",
+        "item": "https://agave-navi.com/?region=%E9%96%A2%E6%9D%B1"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "横浜フラワー&amp;ガーデンフェスティバル 2026"
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
 
-    <script>
-        const toggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('navOverlay');
-        toggle.addEventListener('click', () => {
-            toggle.classList.toggle('active');
-            overlay.classList.toggle('active');
-            document.body.classList.toggle('no-scroll');
-        });
-        overlay.querySelectorAll('a').forEach(link => {
-            link.addEventListener('click', () => {
-                toggle.classList.remove('active');
-                overlay.classList.remove('active');
-                document.body.classList.remove('no-scroll');
-            });
-        });
-    </script>
-    <script>
-        // 行きたい (favorite) functionality
-        const slug = location.pathname.split('/').pop().replace('.html','');
-        function getFavs() {
-            try { return JSON.parse(localStorage.getItem('aen_favs') || '[]'); } catch(e) { return []; }
-        }
-        function toggleFav() {
-            let favs = getFavs();
-            const idx = favs.indexOf(slug);
-            if (idx > -1) { favs.splice(idx, 1); } else { favs.push(slug); }
-            localStorage.setItem('aen_favs', JSON.stringify(favs));
-            updateFavBtn();
-        }
-        function updateFavBtn() {
-            const btn = document.getElementById('favBtn');
-            const label = document.getElementById('favLabel');
-            if (!btn || !label) return;
-            const favs = getFavs();
-            const isFav = favs.includes(slug);
-            if (isFav) {
-                btn.classList.add('is-fav');
-                label.textContent = '行きたい登録済み';
-            } else {
-                btn.classList.remove('is-fav');
-                label.textContent = '行きたい';
-            }
-            // Real-time badge count update
-            var b = document.getElementById('ikitaiBadge');
-            if (b) {
-                if (favs.length > 0) {
-                    b.textContent = favs.length;
-                    b.classList.add('has-count');
-                } else {
-                    b.textContent = '';
-                    b.classList.remove('has-count');
-                }
-            }
-        }
-        updateFavBtn();
-    </script>
-    <script>
-    // Ikitai badge count
-    (function(){
-        var b = document.getElementById('ikitaiBadge');
-        if (!b) return;
-        try {
-            var favs = JSON.parse(localStorage.getItem('aen_favs') || '[]');
-            if (favs.length > 0) {
-                b.textContent = favs.length;
-                b.classList.add('has-count');
-            }
-        } catch(e) {}
-    })();
-    </script>
-    <script src="../affiliate.js"></script>
+  <header class="header">
+    <div class="header-inner">
+      <a href="/" class="logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+        <span class="logo-jp">アガベイベントナビ</span>
+      </a>
+      <div class="header-actions">
+        <a href="../ikitai.html" class="ikitai-blob-btn" id="ikitaiBlobBtn">
+          <span class="blob-bg"></span>
+          <svg class="ikitai-heart" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          <span class="ikitai-label">行きたい</span>
+          <span class="ikitai-badge" id="ikitaiBadge"></span>
+        </a>
+      </div>
+    </div>
+  </header>
 
-<script src="../status-auto.js?v=20260330b"></script>
-<script src="../ads.js"></script>
-<script src="/official-links.js"></script>
+  <nav class="breadcrumb" aria-label="パンくずリスト">
+    <a href="/">ホーム</a> &gt;
+    <a href="/?region=%E9%96%A2%E6%9D%B1">関東のイベント</a> &gt;
+    <span>横浜フラワー&amp;ガーデンフェスティバル 2026</span>
+  </nav>
+
+  <main class="detail-page">
+    <div class="detail-header">
+      <h1>横浜フラワー&amp;ガーデンフェスティバル 2026</h1>
+      <div class="detail-meta">
+        <span class="detail-status-badge" data-date="2026-05-02" data-date-end="2026-05-04"></span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">2026年5月2日（土）</span>
+        <span class="detail-meta-dot"></span>
+        <span class="detail-meta-item">神奈川</span>
+      </div>
+      <div class="detail-header-actions">
+        <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+          </svg>
+          <span id="favLabel">行きたい</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="detail-body">
+      <div class="detail-main">
+        <div class="detail-section">
+          <h2 class="detail-section-title">概要</h2>
+          <p>パシフィコ横浜で開催。GREEN×EXPO 2027プレ企画。バラの展示・ガーデンデザイン・物販。前売¥1,600。</p>
+        </div>
+
+
+
+        <div class="detail-map">
+          <h2 class="detail-section-title">会場</h2>
+          <div class="map-container">
+            <a href="https://www.google.com/maps/search/?api=1&query=%E3%83%91%E3%82%B7%E3%83%95%E3%82%A3%E3%82%B3%E6%A8%AA%E6%B5%9C%2C%E6%A8%AA%E6%B5%9C%E5%B8%82%E8%A5%BF%E5%8C%BA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
+            <iframe src="https://www.google.com/maps?q=%E3%83%91%E3%82%B7%E3%83%95%E3%82%A3%E3%82%B3%E6%A8%AA%E6%B5%9C%2C%E6%A8%AA%E6%B5%9C%E5%B8%82%E8%A5%BF%E5%8C%BA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+
+
+        <div class="detail-back">
+          <a href="/?region=%E9%96%A2%E6%9D%B1" class="detail-back-link">関東のイベントに戻る</a>
+        </div>
+      </div>
+
+      <div class="detail-sidebar">
+        <div class="detail-info-card">
+          <h3>EVENT INFO</h3>
+          <div class="info-row">
+            <span class="info-label">日時</span>
+            <span class="info-value">2026年5月2日（土） 〜 5月4日（月）</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">会場</span>
+            <span class="info-value">パシフィコ横浜 展示ホールA・B</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">開催地域</span>
+            <span class="info-value">関東</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">入場料</span>
+            <span class="info-value">前売¥1,600</span>
+          </div>
+
+
+          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=%E6%A8%AA%E6%B5%9C%E3%83%95%E3%83%A9%E3%83%AF%E3%83%BC%26%E3%82%AC%E3%83%BC%E3%83%87%E3%83%B3%E3%83%95%E3%82%A7%E3%82%B9%E3%83%86%E3%82%A3%E3%83%90%E3%83%AB%202026&dates=20260502%2F20260505&location=%E3%83%91%E3%82%B7%E3%83%95%E3%82%A3%E3%82%B3%E6%A8%AA%E6%B5%9C%20%E5%B1%95%E7%A4%BA%E3%83%9B%E3%83%BC%E3%83%ABA%E3%83%BBB" target="_blank" rel="noopener" class="gcal-btn">
+            &#128197; Googleカレンダーに追加
+          </a>
+        </div>
+
+
+
+      </div>
+
+      <div class="affiliate-section" id="affiliateSection"></div>
+    </div>
+  </main>
+
+  <div class="ad-slot ad-slot-article-bottom" data-ad="article-bottom">
+  </div>
+
+  <div class="ad-affiliate-area" style="max-width:960px;margin:0 auto;padding:0 1rem;">
+    <div class="aff-slot" data-count="5"></div>
+    <div class="ad-slot">
+      <span class="ad-slot-label">広告</span>
+    </div>
+  </div>
+
+  <div class="correction-notice">
+    <p>掲載情報はなるべく精査しておりますが、万が一誤りがある場合は申し訳ございません。お手数をおかけいたしますが、<a href="../contact.html">お問い合わせフォーム</a>からご連絡いただけますと幸いです。</p>
+  </div>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-logo">
+        <span class="logo-en">AGAVE EVENT NAVI</span>
+      </div>
+      <nav class="footer-nav">
+        <a href="/">イベント一覧</a>
+        <a href="/about.html">このサイトについて</a>
+        <a href="/contact.html">お問い合わせ</a>
+        <a href="/disclaimer.html">免責事項</a>
+        <a href="/privacy.html">プライバシーポリシー</a>
+        <a href="/operator.html">運営者情報</a>
+      </nav>
+      <p class="footer-copy">&copy; 2025-2026 アガベイベントナビ</p>
+    </div>
+  </footer>
+
+  <script src="../affiliate.js"></script>
+  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../ads.js"></script>
+  <script>
+    const SLUG = 'yokohama-flower-garden-fes-2026';
+    function toggleFav() {
+      let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const idx = favs.indexOf(SLUG);
+      if (idx >= 0) { favs.splice(idx, 1); }
+      else { favs.push(SLUG); }
+      localStorage.setItem('favEvents', JSON.stringify(favs));
+      updateFavUI();
+    }
+    function updateFavUI() {
+      const favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
+      const btn = document.getElementById('favBtn');
+      const label = document.getElementById('favLabel');
+      if (favs.includes(SLUG)) {
+        btn.classList.add('is-fav');
+        label.textContent = '行きたい！';
+      } else {
+        btn.classList.remove('is-fav');
+        label.textContent = '行きたい';
+      }
+      const badge = document.getElementById('ikitaiBadge');
+      if (badge) badge.textContent = favs.length || '';
+    }
+    updateFavUI();
+  </script>
 </body>
 </html>

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -10,42 +10,42 @@
     gtag('config', 'G-MKY0V1H0HY');
   </script>
   <meta charset="UTF-8">
-  <link rel="canonical" href="https://agave-navi.com/events/grateful-days-10th-osaka-2026.html">
+  <link rel="canonical" href="https://agave-navi.com/events/{{slug}}.html">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Grateful Days 〜 The 10th episode 〜 | アガベイベントナビ</title>
-  <meta name="description" content="大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。">
-  <meta name="keywords" content="Grateful Days 〜 The 10th episode 〜,即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
-  <meta property="og:title" content="Grateful Days 〜 The 10th episode 〜 | アガベイベントナビ">
-  <meta property="og:description" content="大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。">
+  <title>{{name}} | アガベイベントナビ</title>
+  <meta name="description" content="{{metaDescription}}">
+  <meta name="keywords" content="{{name}},即売会,アガベ,多肉植物,塊根植物,コーデックス,ビザールプランツ,即売会,イベント">
+  <meta property="og:title" content="{{name}} | アガベイベントナビ">
+  <meta property="og:description" content="{{metaDescription}}">
   <meta property="og:type" content="article">
-  <meta property="og:url" content="https://agave-navi.com/events/grateful-days-10th-osaka-2026.html">
+  <meta property="og:url" content="https://agave-navi.com/events/{{slug}}.html">
   <meta property="og:image" content="https://agave-navi.com/images/ogp-default.jpg">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="icon" type="image/x-icon" href="../favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="../apple-touch-icon.png">
-  <link rel="stylesheet" href="../style.css?v=20260501a">
+  <link rel="stylesheet" href="../style.css?v={{cssVersion}}">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Event",
-    "name": "Grateful Days 〜 The 10th episode 〜",
-    "startDate": "2026-05-05",
-    "endDate": "2026-05-06",
+    "name": "{{name}}",
+    "startDate": "{{date}}",
+    "endDate": "{{dateEndOrDate}}",
     "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
     "eventStatus": "https://schema.org/EventScheduled",
     "location": {
       "@type": "Place",
-      "name": "大阪",
+      "name": "{{venue}}",
       "address": {
         "@type": "PostalAddress",
-        "addressRegion": "大阪",
+        "addressRegion": "{{prefecture}}",
         "addressCountry": "JP"
       }
     },
-    "description": "大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。",
+    "description": "{{metaDescription}}",
     "organizer": {
       "@type": "Organization",
-      "name": "Grateful Days 〜 The 10th episode 〜"
+      "name": "{{name}}"
     }
   }
   </script>
@@ -63,13 +63,13 @@
       {
         "@type": "ListItem",
         "position": 2,
-        "name": "関西のイベント",
-        "item": "https://agave-navi.com/?region=%E9%96%A2%E8%A5%BF"
+        "name": "{{region}}のイベント",
+        "item": "https://agave-navi.com/?region={{regionEncoded}}"
       },
       {
         "@type": "ListItem",
         "position": 3,
-        "name": "Grateful Days 〜 The 10th episode 〜"
+        "name": "{{name}}"
       }
     ]
   }
@@ -96,19 +96,19 @@
 
   <nav class="breadcrumb" aria-label="パンくずリスト">
     <a href="/">ホーム</a> &gt;
-    <a href="/?region=%E9%96%A2%E8%A5%BF">関西のイベント</a> &gt;
-    <span>Grateful Days 〜 The 10th episode 〜</span>
+    <a href="/?region={{regionEncoded}}">{{region}}のイベント</a> &gt;
+    <span>{{name}}</span>
   </nav>
 
   <main class="detail-page">
     <div class="detail-header">
-      <h1>Grateful Days 〜 The 10th episode 〜</h1>
+      <h1>{{name}}</h1>
       <div class="detail-meta">
-        <span class="detail-status-badge" data-date="2026-05-05" data-date-end="2026-05-06"></span>
+        <span class="detail-status-badge" data-date="{{date}}" data-date-end="{{dateEnd}}"></span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">2026年5月5日（火）</span>
+        <span class="detail-meta-item">{{dateDisplayShort}}</span>
         <span class="detail-meta-dot"></span>
-        <span class="detail-meta-item">大阪</span>
+        <span class="detail-meta-item">{{prefectureOrRegion}}</span>
       </div>
       <div class="detail-header-actions">
         <button class="detail-fav-btn" id="favBtn" onclick="toggleFav()">
@@ -124,22 +124,15 @@
       <div class="detail-main">
         <div class="detail-section">
           <h2 class="detail-section-title">概要</h2>
-          <p>大阪で開催される植物販売イベント、第10回目。アガベ・塊根植物の即売会。</p>
+          <p>{{description}}</p>
         </div>
 
+{{instagramSection}}
 
-
-        <div class="detail-map">
-          <h2 class="detail-section-title">会場</h2>
-          <div class="map-container">
-            <a href="https://www.google.com/maps/search/?api=1&query=%E5%A4%A7%E9%98%AA" target="_blank" rel="noopener" class="map-open-link">マップで開く &#8599;</a>
-            <iframe src="https://www.google.com/maps?q=%E5%A4%A7%E9%98%AA&output=embed" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-          </div>
-        </div>
-
+{{mapSection}}
 
         <div class="detail-back">
-          <a href="/?region=%E9%96%A2%E8%A5%BF" class="detail-back-link">関西のイベントに戻る</a>
+          <a href="/?region={{regionEncoded}}" class="detail-back-link">{{region}}のイベントに戻る</a>
         </div>
       </div>
 
@@ -148,20 +141,20 @@
           <h3>EVENT INFO</h3>
           <div class="info-row">
             <span class="info-label">日時</span>
-            <span class="info-value">2026年5月5日（火） 〜 5月6日（水）</span>
+            <span class="info-value">{{dateDisplayFull}}</span>
           </div>
           <div class="info-row">
             <span class="info-label">会場</span>
-            <span class="info-value">大阪</span>
+            <span class="info-value">{{venue}}</span>
           </div>
           <div class="info-row">
             <span class="info-label">開催地域</span>
-            <span class="info-value">関西</span>
+            <span class="info-value">{{region}}</span>
           </div>
+{{admissionRow}}
+{{timeRow}}
 
-
-
-          <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Grateful%20Days%20%E3%80%9C%20The%2010th%20episode%20%E3%80%9C&dates=20260505%2F20260507&location=%E5%A4%A7%E9%98%AA" target="_blank" rel="noopener" class="gcal-btn">
+          <a href="{{gcalUrl}}" target="_blank" rel="noopener" class="gcal-btn">
             &#128197; Googleカレンダーに追加
           </a>
         </div>
@@ -206,10 +199,10 @@
   </footer>
 
   <script src="../affiliate.js"></script>
-  <script src="../status-auto.js?v=20260501a"></script>
+  <script src="../status-auto.js?v={{jsVersion}}"></script>
   <script src="../ads.js"></script>
   <script>
-    const SLUG = 'grateful-days-10th-osaka-2026';
+    const SLUG = '{{slug}}';
     function toggleFav() {
       let favs = JSON.parse(localStorage.getItem('favEvents') || '[]');
       const idx = favs.indexOf(SLUG);


### PR DESCRIPTION
## Summary
- build-detail-pages.py + templates/detail.html で events.json から全詳細ページを自動生成
- events.json を111件に拡充（日付・会場・地図・入場料等のデータ統合）
- 全100ページのCSS/JSキャッシュバスター統一

## 変更内容
- **新規**: build-detail-pages.py - ビルドスクリプト
- **新規**: templates/detail.html - HTMLテンプレート
- **更新**: events.json - 111件のイベントデータ統合
- **更新**: events/*.html - 100ページをテンプレートから再生成

## 今後のワークフロー
1. events.json を更新
2. python3 build-detail-pages.py を実行
3. 全詳細ページが自動生成